### PR TITLE
Create 'about-pages' and menus

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,3 +18,44 @@ image = "images/icon.png"
 omniture-page-name = "bs:data:news:maryland:politics:voter-guide-2018:dataproject"
 omniture-channel = "news:maryland:politics"
 Year = 2018
+
+
+[[menu.main]]
+url = "http://www.baltimoresun.com/news/maryland/politics/"
+name = "Election Coverage"
+weight = 1
+
+[[menu.main]]
+url = "/"
+name = "Candidates"
+weight = 2
+
+[[menu.main]]
+url = "/dates/"
+name = "Key Dates"
+weight = 3
+
+[[menu.main]]
+url = "http://mdelect.net/"
+name = "Find District"
+weight = 4
+
+[[menu.main]]
+url = "/about/"
+name = "About Questioneers"
+weight = 5
+
+[[menu.main]]
+url = "http://www.tribpub.com/central-terms-of-service/"
+name = "Terms"
+weight = 6
+
+[[menu.main]]
+url = "http://www.tribpub.com/privacy-policy-and-your-privacy-rights/"
+name = "Privacy"
+weight = 7
+
+[[menu.main]]
+url = "mailto:coordinators@baltsun.com"
+name = "Feedback"
+weight = 8

--- a/config.toml
+++ b/config.toml
@@ -42,7 +42,7 @@ weight = 4
 
 [[menu.main]]
 url = "/about/"
-name = "About Questioneers"
+name = "About Questionnaires"
 weight = 5
 
 [[menu.main]]

--- a/content/about.md
+++ b/content/about.md
@@ -1,5 +1,5 @@
 +++
-title = "About the Questioneers"
+title = "About the Questionnaires"
 type = "about-page"
 +++
 

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,6 @@
++++
+title = "About the Questioneers"
+type = "about-page"
++++
+
+Content goes here

--- a/content/dates.md
+++ b/content/dates.md
@@ -1,0 +1,6 @@
++++
+title = "Key Dates for Maryland 2018 Elections"
+type = "about-page"
++++
+
+Content goes here

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,8 @@
 {{ define "main" }}
+<div class="container">
     <h1>Page Not Found</h1>
     <p>
         Sorry, the page you requested could not be found.
     </p>
+</div>
 {{ end }}

--- a/layouts/about-page/single.html
+++ b/layouts/about-page/single.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+<div  class="container">
+    <h1>{{.Title}}</h1>
+    <main>
+        {{ .Content }}
+    </main>
+</div>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,31 +5,13 @@
       <img src='{{ dict "Site" $.Site "Value" "images/sun-logo-footer.gif" | partial "assets.html" }}'>
      </a>
     </div>
+    {{ range .Site.Menus.main }}
     <div class="col-md-offset-1 col-md-2 col-sm-4 col-xs-12">
-     <a href="http://www.baltimoresun.com/news/maryland/politics/" target="_new">
-      ELECTION COVERAGE
+     <a href="{{ .URL }}" class="u-upper">
+      {{ .Name }}
      </a>
     </div>
-    <div class="col-md-2 col-sm-4 col-xs-12">
-     <a href="{{.Site.BaseURL}}">
-      CANDIDATES
-     </a>
-    </div>
-    <div class="col-md-2 col-sm-4 col-xs-12">
-     <a href="http://www.tribpub.com/central-terms-of-service/" target="_new">
-      TERMS
-     </a>
-    </div>
-    <div class="col-md-2 col-sm-4 col-xs-12">
-     <a href="http://www.tribpub.com/privacy-policy-and-your-privacy-rights/" target="_new">
-      PRIVACY
-     </a>
-    </div>
-    <div class="col-md-2 col-sm-4 col-xs-12">
-     <a href="mailto:coordinators@baltsun.com" target="_new">
-      FEEDBACK
-     </a>
-    </div>
+    {{ end }}
     <div class="col-md-12 col-sm-12 col-xs-12 copyright">
      &copy; {{ now.Format "2006" }} ALL RIGHTS RESERVED <br>
      WEBSITE DESIGN BY ADAM MARTON &amp; CAROLINE PATE | SUPPORT BY CARL JOHNSON | CONTENT BY KALANI GORDON

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,31 +9,13 @@
     </div>
     <div id="mobile-nav-drop">
      <ul class="nav-links">
+      {{ range .Site.Menus.main }}
       <li>
-       <a href="http://www.baltimoresun.com/news/maryland/politics/">
-        ELECTION COVERAGE
+       <a href="{{ .URL }}" class="u-upper">
+        {{ .Name }}
        </a>
       </li>
-      <li>
-       <a href="{{ $.Site.BaseURL }}">
-        CANDIDATES
-       </a>
-      </li>
-      <li>
-       <a href="http://www.tribpub.com/central-terms-of-service/">
-        TERMS
-       </a>
-      </li>
-      <li>
-       <a href="http://www.tribpub.com/privacy-policy-and-your-privacy-rights/">
-        PRIVACY
-       </a>
-      </li>
-      <li>
-       <a href="mailto:coordinators@baltsun.com">
-        FEEDBACK
-       </a>
-      </li>
+      {{ end }}
      </ul>
     </div>
     <div id="star-and-logo">

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -1516,7 +1516,6 @@ p.about {
     border-top: 1px solid white;
     left: 0px;
     right: 0px;
-    height: 200px;
     padding-left: 10px;
   }
 }
@@ -1696,6 +1695,10 @@ p.about {
 
 .u-none {
   display: none;
+}
+
+.u-upper {
+  text-transform: uppercase;
 }
 
 th {


### PR DESCRIPTION
This consolidates the menus in the mobile nav and footer by having them both powered by the config file.

It also creates a new page type called "about-page" uses that to power the pages for the Key Dates and About Questionnaire menu items.