### PR TITLE
Create a basic version of Robocopy so we can work on frontend too

### DIFF
--- a/cmd/robocopy/controller.go
+++ b/cmd/robocopy/controller.go
@@ -2,16 +2,18 @@ package main
 
 import "time"
 
+type SubResult struct {
+	Jurisdiction string
+	District     string
+	TotalVotes   int
+}
+
 type OptionResult struct {
 	Text         string
 	TotalVotes   int
 	Jurisdiction string
 	District     string
-	SubResults   []struct {
-		Jurisdiction string
-		District     string
-		TotalVotes   int
-	}
+	SubResults   []SubResult
 }
 
 type Result struct {
@@ -61,6 +63,7 @@ func MapContestResults(m *Metadata, rc *ResultsContainer) map[ContestID]*Result 
 				Text:         m.Options[rawResult.OptionID].Text,
 				District:     m.Districts[did].Name,
 				Jurisdiction: m.Jurisdictions[jid].Name,
+				SubResults:   []SubResult{},
 			})
 
 			option = &result.Options[len(result.Options)-1]
@@ -69,7 +72,13 @@ func MapContestResults(m *Metadata, rc *ResultsContainer) map[ContestID]*Result 
 		if contest.District == rawResult.DistrictID {
 			option.TotalVotes = rawResult.TotalVotes
 		} else {
-			// make a list of subresults
+			dist := rawResult.DistrictID.From(m)
+			jur := rawResult.JurisdictionID.From(m)
+			option.SubResults = append(option.SubResults, SubResult{
+				District:     dist.Name,
+				Jurisdiction: jur.Name,
+				TotalVotes:   rawResult.TotalVotes,
+			})
 		}
 	}
 	return contests

--- a/cmd/robocopy/controller.go
+++ b/cmd/robocopy/controller.go
@@ -1,0 +1,73 @@
+package main
+
+import "time"
+
+type OptionResult struct {
+	Text         string
+	TotalVotes   int
+	Jurisdiction string
+	District     string
+	SubResults   []struct {
+		Jurisdiction string
+		District     string
+		TotalVotes   int
+	}
+}
+
+type Result struct {
+	LastUpdate           time.Time
+	Contest              string
+	District             string
+	Jurisdiction         string
+	Party                string
+	VoteFor              int
+	PrimaryDescription   string
+	SecondaryDescription string
+	FullDescription      string
+
+	Options []OptionResult
+	om      map[OptionID]*OptionResult
+}
+
+func MapContestResults(m *Metadata, rc *ResultsContainer) map[ContestID]*Result {
+	contests := make(map[ContestID]*Result)
+	for _, rawResult := range rc.Results {
+		cid := m.OptionParents[rawResult.OptionID]
+		contest := m.Contests[cid]
+
+		result, ok := contests[cid]
+		if !ok {
+			result = &Result{}
+			result.LastUpdate = rc.LastUpdate
+			result.Contest = contest.Name
+			dist := m.Districts[contest.District]
+			result.District = dist.Name
+			result.Jurisdiction = m.Jurisdictions[dist.Parent].Name
+			result.Party = m.Parties[contest.PartyID].Description
+			result.VoteFor = contest.VoteFor
+			result.PrimaryDescription = contest.PrimaryDescription
+			result.SecondaryDescription = contest.SecondaryDescription
+			result.FullDescription = contest.FullDescription
+			result.om = make(map[OptionID]*OptionResult)
+			contests[cid] = result
+		}
+
+		// rawOption := m.Options[rawResult.OptionID]
+		option, ok := result.om[rawResult.OptionID]
+		if !ok {
+			option = &OptionResult{}
+			option.Text = m.Options[rawResult.OptionID].Text
+			did := contest.District
+			option.District = m.Districts[did].Name
+			jid := m.Districts[did].Parent
+			option.Jurisdiction = m.Jurisdictions[jid].Name
+			result.om[rawResult.OptionID] = option
+		}
+		if contest.District == rawResult.DistrictID {
+			option.TotalVotes = rawResult.TotalVotes
+		} else {
+			// make a list of subresults
+		}
+	}
+	return contests
+}

--- a/cmd/robocopy/controller.go
+++ b/cmd/robocopy/controller.go
@@ -55,12 +55,15 @@ func MapContestResults(m *Metadata, rc *ResultsContainer) map[ContestID]*Result 
 		// rawOption := m.Options[rawResult.OptionID]
 		option, ok := result.om[rawResult.OptionID]
 		if !ok {
-			option = &OptionResult{}
-			option.Text = m.Options[rawResult.OptionID].Text
 			did := contest.District
-			option.District = m.Districts[did].Name
 			jid := m.Districts[did].Parent
-			option.Jurisdiction = m.Jurisdictions[jid].Name
+			result.Options = append(result.Options, OptionResult{
+				Text:         m.Options[rawResult.OptionID].Text,
+				District:     m.Districts[did].Name,
+				Jurisdiction: m.Jurisdictions[jid].Name,
+			})
+
+			option = &result.Options[len(result.Options)-1]
 			result.om[rawResult.OptionID] = option
 		}
 		if contest.District == rawResult.DistrictID {

--- a/cmd/robocopy/json.go
+++ b/cmd/robocopy/json.go
@@ -227,23 +227,23 @@ const (
 	AllWriteInCandidates          = 'A'
 )
 
-func (id ContestID) From(m Metadata) Contest {
+func (id ContestID) From(m *Metadata) Contest {
 	return m.Contests[id]
 }
 
-func (id DistrictTypeID) From(m Metadata) DistrictType {
+func (id DistrictTypeID) From(m *Metadata) DistrictType {
 	return m.DistrictTypes[id]
 }
 
-func (id DistrictID) From(m Metadata) District {
+func (id DistrictID) From(m *Metadata) District {
 	return m.Districts[id]
 }
 
-func (id JurisdictionID) From(m Metadata) Jurisdiction {
+func (id JurisdictionID) From(m *Metadata) Jurisdiction {
 	return m.Jurisdictions[id]
 }
 
-func (id PartyID) From(m Metadata) Party {
+func (id PartyID) From(m *Metadata) Party {
 	return m.Parties[id]
 }
 

--- a/cmd/robocopy/json.go
+++ b/cmd/robocopy/json.go
@@ -227,6 +227,26 @@ const (
 	AllWriteInCandidates          = 'A'
 )
 
+func (id ContestID) From(m Metadata) Contest {
+	return m.Contests[id]
+}
+
+func (id DistrictTypeID) From(m Metadata) DistrictType {
+	return m.DistrictTypes[id]
+}
+
+func (id DistrictID) From(m Metadata) District {
+	return m.Districts[id]
+}
+
+func (id JurisdictionID) From(m Metadata) Jurisdiction {
+	return m.Jurisdictions[id]
+}
+
+func (id PartyID) From(m Metadata) Party {
+	return m.Parties[id]
+}
+
 type Metadata struct {
 	ElectionDate  time.Time
 	ElectionType  string

--- a/cmd/robocopy/json.go
+++ b/cmd/robocopy/json.go
@@ -258,6 +258,21 @@ type Metadata struct {
 	Parties       map[PartyID]Party
 }
 
+func MetadataFrom(name string) (m *Metadata, err error) {
+	rc, err := readFrom(name)
+	if err != nil {
+		return nil, fmt.Errorf("could not open metadata: %v", err)
+	}
+	defer deferClose(&err, rc.Close)
+
+	m = &Metadata{}
+	dec := json.NewDecoder(BOMReader(rc))
+	if err = dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("could not decode metadata: %v", err)
+	}
+	return m, err
+}
+
 func (m *Metadata) UnmarshalJSON(b []byte) error {
 	var raw metadataJSON
 	err := json.Unmarshal(b, &raw)

--- a/cmd/robocopy/json.go
+++ b/cmd/robocopy/json.go
@@ -252,6 +252,8 @@ type Metadata struct {
 	ElectionType  string
 	IsPrimary     bool
 	Contests      map[ContestID]Contest
+	Options       map[OptionID]*Option
+	OptionParents map[OptionID]ContestID
 	DistrictTypes map[DistrictTypeID]DistrictType
 	Districts     map[DistrictID]District
 	Jurisdictions map[JurisdictionID]Jurisdiction
@@ -288,6 +290,8 @@ func (m *Metadata) UnmarshalJSON(b []byte) error {
 	m.IsPrimary = raw.IsPrimary == "Yes"
 
 	m.Contests = make(map[ContestID]Contest, len(raw.Contests))
+	m.Options = make(map[OptionID]*Option)
+	m.OptionParents = make(map[OptionID]ContestID)
 	for _, c := range raw.Contests {
 		nc := Contest{
 			BallotDistrict:       DistrictID(c.BallotDistrict),
@@ -314,6 +318,8 @@ func (m *Metadata) UnmarshalJSON(b []byte) error {
 				WriteIn: o.WriteIn[0],
 			}
 			nc.Options = append(nc.Options, no)
+			m.Options[no.ID] = &nc.Options[len(nc.Options)-1]
+			m.OptionParents[no.ID] = nc.ID
 		}
 		m.Contests[nc.ID] = nc
 	}
@@ -384,15 +390,20 @@ func (m *Metadata) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-type Results struct {
+type ResultsContainer struct {
 	Test       bool
 	LastUpdate time.Time
 	Results    []struct {
-		OptionID, JurisdictionID, DistrictID, TotalVotes int
+		OptionID
+		JurisdictionID
+		DistrictID
+		TotalVotes int
 	}
 	DistrictReporting []struct {
-		JurisdictionID, DistrictID, PrecinctsReporting, TotalPrecincts int
-		PercentCounted                                                 float64
+		JurisdictionID
+		DistrictID
+		PrecinctsReporting, TotalPrecincts int
+		PercentCounted                     float64
 	}
 	Reporting []struct {
 		PrecinctID       int
@@ -410,7 +421,7 @@ type Results struct {
 	}
 }
 
-func (r *Results) UnmarshalJSON(b []byte) error {
+func (r *ResultsContainer) UnmarshalJSON(b []byte) error {
 	/*
 	   Test:<If this is a test feed>,
 	   LastUpdate:<Dateand Time of Last Updatein the format “YYYY-MM-DD HH:mm:SS”>,
@@ -439,21 +450,26 @@ func (r *Results) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	r.Results = make([]struct {
-		OptionID, JurisdictionID, DistrictID, TotalVotes int
+		OptionID
+		JurisdictionID
+		DistrictID
+		TotalVotes int
 	}, len(raw.Results))
 	for i := range raw.Results {
-		r.Results[i].OptionID = raw.Results[i][0]
-		r.Results[i].JurisdictionID = raw.Results[i][1]
-		r.Results[i].DistrictID = raw.Results[i][2]
+		r.Results[i].OptionID = OptionID(raw.Results[i][0])
+		r.Results[i].JurisdictionID = JurisdictionID(raw.Results[i][1])
+		r.Results[i].DistrictID = DistrictID(raw.Results[i][2])
 		r.Results[i].TotalVotes = raw.Results[i][3]
 	}
 	r.DistrictReporting = make([]struct {
-		JurisdictionID, DistrictID, PrecinctsReporting, TotalPrecincts int
-		PercentCounted                                                 float64
+		JurisdictionID
+		DistrictID
+		PrecinctsReporting, TotalPrecincts int
+		PercentCounted                     float64
 	}, len(raw.DReporting))
 	for i := range raw.DReporting {
-		r.DistrictReporting[i].JurisdictionID = int(raw.DReporting[i][0])
-		r.DistrictReporting[i].DistrictID = int(raw.DReporting[i][1])
+		r.DistrictReporting[i].JurisdictionID = JurisdictionID(raw.DReporting[i][0])
+		r.DistrictReporting[i].DistrictID = DistrictID(raw.DReporting[i][1])
 		r.DistrictReporting[i].PrecinctsReporting = int(raw.DReporting[i][2])
 		r.DistrictReporting[i].TotalPrecincts = int(raw.DReporting[i][3])
 		r.DistrictReporting[i].PercentCounted = raw.DReporting[i][4]

--- a/cmd/robocopy/json.go
+++ b/cmd/robocopy/json.go
@@ -421,6 +421,20 @@ type ResultsContainer struct {
 	}
 }
 
+func ResultsContainerFrom(name string) (r *ResultsContainer, err error) {
+	rc, err := readFrom(name)
+	if err != nil {
+		return nil, fmt.Errorf("could not open results: %v", err)
+	}
+	defer deferClose(&err, rc.Close)
+
+	r = &ResultsContainer{}
+	dec := json.NewDecoder(BOMReader(rc))
+	if err = dec.Decode(&r); err != nil {
+		return nil, fmt.Errorf("could not decode results: %v", err)
+	}
+	return r, err
+}
 func (r *ResultsContainer) UnmarshalJSON(b []byte) error {
 	/*
 	   Test:<If this is a test feed>,

--- a/cmd/robocopy/json_test.go
+++ b/cmd/robocopy/json_test.go
@@ -56,9 +56,9 @@ func TestUnmarshallJSON(t *testing.T) {
 		{"old-results", "test/Results.js", &Results{}},
 		{"new-precinct-results", "test/GP18-PrecinctResults.js", &PrecinctResults{}},
 		{"new-results", "test/GP18-Results.js", &Results{}},
-		{"live-metadata", "http://elections.maryland.gov/elections/results_data/GP18/MetaData.js", &Metadata{}},
-		{"live-precinct-results", "http://elections.maryland.gov/elections/results_data/GP18/PrecinctResults.js", &PrecinctResults{}},
-		{"live-results", "http://elections.maryland.gov/elections/results_data/GP18/Results.js", &Results{}},
+		{"live-metadata", metadata18url, &Metadata{}},
+		{"live-precinct-results", precinctResults18url, &PrecinctResults{}},
+		{"live-results", results18url, &Results{}},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestMetadataObj(t *testing.T) {
 	}{
 		{"new-metadata", "test/GP18-Metadata.js"},
 		{"old-metadata", "test/Metadata.js"},
-		{"live-metadata", "http://elections.maryland.gov/elections/results_data/GP18/MetaData.js"},
+		{"live-metadata", metadata18url},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/robocopy/model.go
+++ b/cmd/robocopy/model.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -26,38 +25,27 @@ func (c Contest) Jurisdiction(m Metadata) string {
 }
 
 func (m *Metadata) MarshalJSON() (b []byte, err error) {
-	// This JSON is a turkducken of crud trying to invert the contests into something useful
-	type contestReturnJSON struct {
-		Name  string
-		Party string
-		ID    int
-	}
-	type districtReturnJSON struct {
-		Name     string
-		Contests []contestReturnJSON
-	}
-	type jurisdictionReturnJSON struct {
-		Name      string
-		Districts []districtReturnJSON
-		dmap      map[DistrictID]*districtReturnJSON
-	}
+	// Make a list of all contests for use in template
 	type raceReturnJSON struct {
-		Name          string
-		Jurisdictions []jurisdictionReturnJSON
-		jmap          map[JurisdictionID]*jurisdictionReturnJSON
+		Name         string
+		Jurisdiction string
+		District     string
+		Party        string
+		ID           int
 	}
 	type metadataReturnJSON struct {
 		ElectionDate *time.Time
 		ElectionType *string
 		IsPrimary    *bool
-		Contests     []raceReturnJSON
+		AllContests  []raceReturnJSON
 	}
 	var r = metadataReturnJSON{
 		ElectionDate: &m.ElectionDate,
 		ElectionType: &m.ElectionType,
 		IsPrimary:    &m.IsPrimary,
 	}
-	// Do a lot of work to group things together logically
+
+	// sort by BoE order
 	cids := make([]ContestID, 0, len(m.Contests))
 	for cid := range m.Contests {
 		cids = append(cids, cid)
@@ -65,48 +53,19 @@ func (m *Metadata) MarshalJSON() (b []byte, err error) {
 	sort.Slice(cids, func(i, j int) bool {
 		return m.Contests[cids[i]].Order < m.Contests[cids[j]].Order
 	})
-	races := map[string]*raceReturnJSON{}
+
 	for _, cid := range cids {
-		raceName := m.Contests[cid].Name
-		raceName = strings.TrimSuffix(raceName, " At Large")
-		raceName = strings.TrimSuffix(raceName, " Male")
-		raceName = strings.TrimSuffix(raceName, " Female")
-		race, ok := races[raceName]
-		if !ok {
-			r.Contests = append(r.Contests, raceReturnJSON{
-				Name: raceName,
-				jmap: make(map[JurisdictionID]*jurisdictionReturnJSON),
-			})
-			race = &r.Contests[len(r.Contests)-1]
-			races[raceName] = race
-		}
-
-		did := m.Contests[cid].District
-		jid := m.Districts[did].Parent
-		jur, ok := race.jmap[jid]
-		if !ok {
-			race.Jurisdictions = append(race.Jurisdictions, jurisdictionReturnJSON{
-				Name: m.Jurisdictions[jid].Name,
-				dmap: make(map[DistrictID]*districtReturnJSON),
-			})
-			jur = &race.Jurisdictions[len(race.Jurisdictions)-1]
-			race.jmap[jid] = jur
-		}
-
-		dist, ok := jur.dmap[did]
-		if !ok {
-			jur.Districts = append(jur.Districts, districtReturnJSON{
-				Name: m.Districts[did].Name,
-			})
-			dist = &jur.Districts[len(jur.Districts)-1]
-		}
-
-		dist.Contests = append(dist.Contests, contestReturnJSON{
-			Name:  m.Contests[cid].Name,
-			Party: m.Parties[m.Contests[cid].PartyID].Code,
-			ID:    int(m.Contests[cid].ID),
+		con := m.Contests[cid]
+		dist := m.Districts[con.District]
+		jur := m.Jurisdictions[dist.Parent]
+		party := m.Parties[con.PartyID]
+		r.AllContests = append(r.AllContests, raceReturnJSON{
+			Name:         con.Name,
+			Jurisdiction: jur.Name,
+			District:     dist.Name,
+			Party:        party.Description,
+			ID:           int(cid),
 		})
-
 	}
 	return json.Marshal(&r)
 }

--- a/cmd/robocopy/model.go
+++ b/cmd/robocopy/model.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+func (c Contest) Party(m Metadata) string {
+	return c.PartyID.From(m).Code
+}
+
+func (c Contest) DistrictName(m Metadata) string {
+	d := c.District.From(m)
+	return d.Name
+}
+
+func (c Contest) Jurisdiction(m Metadata) string {
+	d := c.District.From(m)
+	p := d.Parent.From(m)
+	if p.Name == d.Name {
+		return ""
+	}
+	return p.Name
+}
+
+func (m *Metadata) MarshalJSON() (b []byte, err error) {
+	// This JSON is a turkducken of crud trying to invert the contests into something useful
+	type contestReturnJSON struct {
+		Name  string
+		Party string
+		ID    int
+	}
+	type districtReturnJSON struct {
+		Name     string
+		Contests []contestReturnJSON
+	}
+	type jurisdictionReturnJSON struct {
+		Name      string
+		Districts []districtReturnJSON
+		dmap      map[DistrictID]*districtReturnJSON
+	}
+	type raceReturnJSON struct {
+		Name          string
+		Jurisdictions []jurisdictionReturnJSON
+		jmap          map[JurisdictionID]*jurisdictionReturnJSON
+	}
+	type metadataReturnJSON struct {
+		ElectionDate *time.Time
+		ElectionType *string
+		IsPrimary    *bool
+		Contests     []raceReturnJSON
+	}
+	var r = metadataReturnJSON{
+		ElectionDate: &m.ElectionDate,
+		ElectionType: &m.ElectionType,
+		IsPrimary:    &m.IsPrimary,
+	}
+	// Do a lot of work to group things together logically
+	cids := make([]ContestID, 0, len(m.Contests))
+	for cid := range m.Contests {
+		cids = append(cids, cid)
+	}
+	sort.Slice(cids, func(i, j int) bool {
+		return m.Contests[cids[i]].Order < m.Contests[cids[j]].Order
+	})
+	races := map[string]*raceReturnJSON{}
+	for _, cid := range cids {
+		raceName := m.Contests[cid].Name
+		raceName = strings.TrimSuffix(raceName, " At Large")
+		raceName = strings.TrimSuffix(raceName, " Male")
+		raceName = strings.TrimSuffix(raceName, " Female")
+		race, ok := races[raceName]
+		if !ok {
+			r.Contests = append(r.Contests, raceReturnJSON{
+				Name: raceName,
+				jmap: make(map[JurisdictionID]*jurisdictionReturnJSON),
+			})
+			race = &r.Contests[len(r.Contests)-1]
+			races[raceName] = race
+		}
+
+		did := m.Contests[cid].District
+		jid := m.Districts[did].Parent
+		jur, ok := race.jmap[jid]
+		if !ok {
+			race.Jurisdictions = append(race.Jurisdictions, jurisdictionReturnJSON{
+				Name: m.Jurisdictions[jid].Name,
+				dmap: make(map[DistrictID]*districtReturnJSON),
+			})
+			jur = &race.Jurisdictions[len(race.Jurisdictions)-1]
+			race.jmap[jid] = jur
+		}
+
+		dist, ok := jur.dmap[did]
+		if !ok {
+			jur.Districts = append(jur.Districts, districtReturnJSON{
+				Name: m.Jurisdictions[jid].Name,
+			})
+			dist = &jur.Districts[len(jur.Districts)-1]
+		}
+
+		dist.Contests = append(dist.Contests, contestReturnJSON{
+			Name:  m.Contests[cid].Name,
+			Party: m.Parties[m.Contests[cid].PartyID].Code,
+			ID:    int(m.Contests[cid].ID),
+		})
+
+	}
+	return json.Marshal(&r)
+}

--- a/cmd/robocopy/model.go
+++ b/cmd/robocopy/model.go
@@ -96,7 +96,7 @@ func (m *Metadata) MarshalJSON() (b []byte, err error) {
 		dist, ok := jur.dmap[did]
 		if !ok {
 			jur.Districts = append(jur.Districts, districtReturnJSON{
-				Name: m.Jurisdictions[jid].Name,
+				Name: m.Districts[did].Name,
 			})
 			dist = &jur.Districts[len(jur.Districts)-1]
 		}

--- a/cmd/robocopy/model.go
+++ b/cmd/robocopy/model.go
@@ -6,16 +6,22 @@ import (
 	"time"
 )
 
-func (c Contest) Party(m Metadata) string {
+func (c Contest) Party(m *Metadata) string {
 	return c.PartyID.From(m).Code
 }
 
-func (c Contest) DistrictName(m Metadata) string {
+func (c Contest) DistrictJurisdiction(m *Metadata) (dist, jur string) {
+	d := c.District.From(m)
+	p := d.Parent.From(m)
+	return d.Name, p.Name
+}
+
+func (c Contest) DistrictName(m *Metadata) string {
 	d := c.District.From(m)
 	return d.Name
 }
 
-func (c Contest) Jurisdiction(m Metadata) string {
+func (c Contest) Jurisdiction(m *Metadata) string {
 	d := c.District.From(m)
 	p := d.Parent.From(m)
 	if p.Name == d.Name {

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -30,6 +30,7 @@ func main() {
 
 type Config struct {
 	Local            bool
+	CreateResults    bool
 	MetadataLocation string
 	OutputDir        string
 }
@@ -38,6 +39,7 @@ func FromArgs(args []string) *Config {
 	conf := &Config{}
 	fl := flag.NewFlagSet("robocopy", flag.ExitOnError)
 	fl.BoolVar(&conf.Local, "local", false, "just save files local")
+	fl.BoolVar(&conf.CreateResults, "results", false, "create results metadata file")
 	fl.StringVar(&conf.MetadataLocation, "metadata-src", metadata18url, "url or filename for metadata")
 	fl.StringVar(&conf.OutputDir, "output-dir", "static/results/", "directory to save into")
 	fl.Usage = func() {
@@ -65,7 +67,14 @@ func (c *Config) Exec() error {
 		return err
 	}
 
-	return c.createJSON("metadata.json", m)
+	if c.CreateResults {
+		err = c.createJSON("results.json", m)
+		if err != nil {
+			return fmt.Errorf("could not create results file: %v", err)
+		}
+	}
+
+	return nil
 }
 
 func (c *Config) createJSON(filename string, data interface{}) (err error) {

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -32,6 +32,7 @@ type Config struct {
 	Local            bool
 	CreateResults    bool
 	MetadataLocation string
+	ResultsLocation  string
 	OutputDir        string
 }
 
@@ -41,6 +42,7 @@ func FromArgs(args []string) *Config {
 	fl.BoolVar(&conf.Local, "local", false, "just save files local")
 	fl.BoolVar(&conf.CreateResults, "results", false, "create results metadata file")
 	fl.StringVar(&conf.MetadataLocation, "metadata-src", metadata18url, "url or filename for metadata")
+	fl.StringVar(&conf.ResultsLocation, "results-src", results18url, "url or filename for results")
 	fl.StringVar(&conf.OutputDir, "output-dir", "static/results/", "directory to save into")
 	fl.Usage = func() {
 		fmt.Fprintf(os.Stderr,
@@ -72,6 +74,17 @@ func (c *Config) Exec() error {
 		if err != nil {
 			return fmt.Errorf("could not create results file: %v", err)
 		}
+	}
+
+	r, err := ResultsContainerFrom(c.ResultsLocation)
+	if err != nil {
+		return err
+	}
+
+	cr := MapContestResults(m, r)
+	err = c.createJSON("test.json", &cr)
+	if err != nil {
+		return fmt.Errorf("could not create results file: %v", err)
 	}
 
 	return nil

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	results18url         = "http://elections.maryland.gov/elections/results_data/GP18/Results.js"
+	precinctResults18url = "http://elections.maryland.gov/elections/results_data/GP18/PrecinctResults.js"
+	metadata18url        = "http://elections.maryland.gov/elections/results_data/GP18/MetaData.js"
+)
+
+func init() {
+	http.DefaultClient.Timeout = 60 * time.Second
+}
+
+func main() {
+	c := FromArgs(os.Args[1:])
+	if err := c.Exec(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type Config struct {
+	Local            bool
+	MetadataLocation string
+}
+
+func FromArgs(args []string) *Config {
+	conf := &Config{}
+	fl := flag.NewFlagSet("robocopy", flag.ExitOnError)
+	fl.BoolVar(&conf.Local, "local", false, "just save files local")
+	fl.StringVar(&conf.MetadataLocation, "metadata-src", metadata18url, "url or filename for metadata")
+	fl.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			`robocopy
+
+Usage of robocopy:
+
+`,
+		)
+		fl.PrintDefaults()
+	}
+	_ = fl.Parse(args)
+
+	return conf
+}
+
+func (c *Config) Exec() error {
+	if !c.Local {
+		return fmt.Errorf("not implemented")
+	}
+
+	m, err := MetadataFrom(c.MetadataLocation)
+	if err != nil {
+		return err
+	}
+
+	err = templates.ExecuteTemplate(os.Stdout, "metadata", m)
+	return err
+}

--- a/cmd/robocopy/templates.go
+++ b/cmd/robocopy/templates.go
@@ -4,19 +4,90 @@ import "html/template"
 
 var templates = template.Must(template.New("name").Parse(`
 
-{{ define "metadata" }}
-    <table>
-    {{ $m := . }}
-    {{ range $c := .Contests }}
-        <tr class="contest">
-            <td class="jurisdiction">{{ $c.Jurisdiction $m }}</td>
-            <td class="name">{{ $c.Name }}</td>
-            <td class="district">{{ $c.DistrictName $m }}</td>
-            <td class="party">{{ $c.Party $m }}</td>
-            <td>Pick {{ $c.VoteFor }}</td>
-        </tr>
+{{ define "contest" }}
+<table>
+    <tr>
+        <td>LastUpdate</td>
+        <td>{{ .LastUpdate }}</td>
+    </tr>
+    <tr>
+        <td>Contest</td>
+        <td>{{ .Contest }}</td>
+    </tr>
+    <tr>
+        <td>District</td>
+        <td>{{ .District }}</td>
+    </tr>
+    <tr>
+        <td>Jurisdiction</td>
+        <td>{{ .Jurisdiction }}</td>
+    </tr>
+    <tr>
+        <td>Party</td>
+        <td>{{ .Party }}</td>
+    </tr>
+    <tr>
+        <td>VoteFor</td>
+        <td>{{ .VoteFor }}</td>
+    </tr>
+    <tr>
+        <td>PrimaryDescription</td>
+        <td>{{ .PrimaryDescription }}</td>
+    </tr>
+    <tr>
+        <td>SecondaryDescription</td>
+        <td>{{ .SecondaryDescription }}</td>
+    </tr>
+    <tr>
+        <td>FullDescription</td>
+        <td>{{ .FullDescription }}</td>
+    </tr>
+</table>
+<ul>
+    {{ range .Options }}
+    <li>
+        <table>
+            <tr>
+                <td>Text</td>
+                <td>{{ .Text }}</td>
+            </tr>
+            <tr>
+                <td>TotalVotes</td>
+                <td>{{ .TotalVotes }}</td>
+            </tr>
+            <tr>
+                <td>Jurisdiction</td>
+                <td>{{ .Jurisdiction }}</td>
+            </tr>
+            <tr>
+                <td>District</td>
+                <td>{{ .District }}</td>
+            </tr>
+        </table>
+        SubResults
+        <ul>
+        {{ range .SubResults }}
+        <li>
+        <table>
+            <tr>
+                <td>Jurisdiction</td>
+                <td>{{ .Jurisdiction }}</td>
+            </tr>
+            <tr>
+                <td>District</td>
+                <td>{{ .District }}</td>
+            </tr>
+            <tr>
+                <td>TotalVotes</td>
+                <td>{{ .TotalVotes }}</td>
+            </tr>
+        </table>
+        </li>
+        {{ end }}
+        </ul>
+    </li>
     {{ end }}
-    </ul>
+</ul>
 {{ end }}
 
 `))

--- a/cmd/robocopy/templates.go
+++ b/cmd/robocopy/templates.go
@@ -5,9 +5,16 @@ import "html/template"
 var templates = template.Must(template.New("name").Parse(`
 
 {{ define "metadata" }}
-    <ul>
-    {{ range .Contests }}
-        <li>{{ .Name }}</li>
+    <table>
+    {{ $m := . }}
+    {{ range $c := .Contests }}
+        <tr class="contest">
+            <td class="jurisdiction">{{ $c.Jurisdiction $m }}</td>
+            <td class="name">{{ $c.Name }}</td>
+            <td class="district">{{ $c.DistrictName $m }}</td>
+            <td class="party">{{ $c.Party $m }}</td>
+            <td>Pick {{ $c.VoteFor }}</td>
+        </tr>
     {{ end }}
     </ul>
 {{ end }}

--- a/cmd/robocopy/templates.go
+++ b/cmd/robocopy/templates.go
@@ -1,0 +1,15 @@
+package main
+
+import "html/template"
+
+var templates = template.Must(template.New("name").Parse(`
+
+{{ define "metadata" }}
+    <ul>
+    {{ range .Contests }}
+        <li>{{ .Name }}</li>
+    {{ end }}
+    </ul>
+{{ end }}
+
+`))

--- a/cmd/robocopy/utils.go
+++ b/cmd/robocopy/utils.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"io"
+	"net/http"
+	"os"
+	"strings"
 
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -9,4 +12,21 @@ import (
 
 func BOMReader(r io.Reader) io.Reader {
 	return transform.NewReader(r, unicode.BOMOverride(unicode.UTF8.NewDecoder()))
+}
+
+func deferClose(err *error, f func() error) {
+	newErr := f()
+	if *err == nil {
+		*err = newErr
+	}
+}
+
+func readFrom(name string) (rc io.ReadCloser, err error) {
+	if strings.HasPrefix(name, "http") {
+		rsp, err := http.Get(name)
+		return rsp.Body, err
+	}
+
+	f, err := os.Open(name)
+	return f, err
 }

--- a/data/results.json
+++ b/data/results.json
@@ -2,6 +2,22 @@
   "ElectionDate": "2018-06-26T00:00:00Z",
   "ElectionType": "Gubernatorial",
   "IsPrimary": true,
+  "KeyContests": [
+    {
+      "Name": "Governor / Lt. Governor",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Democrat",
+      "ID": 1
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Democrat",
+      "ID": 454
+    }
+  ],
   "AllContests": [
     {
       "Name": "Governor / Lt. Governor",

--- a/data/results.json
+++ b/data/results.json
@@ -1,0 +1,6006 @@
+{
+  "ElectionDate": "2018-06-26T00:00:00Z",
+  "ElectionType": "Gubernatorial",
+  "IsPrimary": true,
+  "AllContests": [
+    {
+      "Name": "Governor / Lt. Governor",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Democrat",
+      "ID": 1
+    },
+    {
+      "Name": "Governor / Lt. Governor",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Republican",
+      "ID": 2
+    },
+    {
+      "Name": "Comptroller",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Democrat",
+      "ID": 3
+    },
+    {
+      "Name": "Comptroller",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Republican",
+      "ID": 4
+    },
+    {
+      "Name": "Attorney General",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Democrat",
+      "ID": 5
+    },
+    {
+      "Name": "Attorney General",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Republican",
+      "ID": 6
+    },
+    {
+      "Name": "U.S. Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Republican",
+      "ID": 7
+    },
+    {
+      "Name": "U.S. Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Party": "Democrat",
+      "ID": 8
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 1",
+      "Party": "Republican",
+      "ID": 9
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 1",
+      "Party": "Democrat",
+      "ID": 10
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 2",
+      "Party": "Republican",
+      "ID": 11
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 2",
+      "Party": "Democrat",
+      "ID": 12
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 3",
+      "Party": "Democrat",
+      "ID": 13
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 3",
+      "Party": "Republican",
+      "ID": 14
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 4",
+      "Party": "Democrat",
+      "ID": 15
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 4",
+      "Party": "Republican",
+      "ID": 16
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 5",
+      "Party": "Republican",
+      "ID": 17
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 5",
+      "Party": "Democrat",
+      "ID": 18
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 6",
+      "Party": "Democrat",
+      "ID": 19
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 6",
+      "Party": "Republican",
+      "ID": 20
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 7",
+      "Party": "Republican",
+      "ID": 21
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 7",
+      "Party": "Democrat",
+      "ID": 22
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 8",
+      "Party": "Democrat",
+      "ID": 23
+    },
+    {
+      "Name": "Representative in Congress",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 8",
+      "Party": "Republican",
+      "ID": 24
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1",
+      "Party": "Republican",
+      "ID": 25
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2",
+      "Party": "Republican",
+      "ID": 26
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3",
+      "Party": "Republican",
+      "ID": 27
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3",
+      "Party": "Democrat",
+      "ID": 28
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 4",
+      "Party": "Republican",
+      "ID": 29
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 4",
+      "Party": "Democrat",
+      "ID": 30
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 5",
+      "Party": "Republican",
+      "ID": 31
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 5",
+      "Party": "Democrat",
+      "ID": 32
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Party": "Democrat",
+      "ID": 33
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Party": "Republican",
+      "ID": 34
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Republican",
+      "ID": 35
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Democrat",
+      "ID": 36
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Party": "Republican",
+      "ID": 37
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Party": "Democrat",
+      "ID": 38
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9",
+      "Party": "Republican",
+      "ID": 39
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9",
+      "Party": "Democrat",
+      "ID": 40
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Party": "Democrat",
+      "ID": 41
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Party": "Republican",
+      "ID": 42
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Party": "Democrat",
+      "ID": 43
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Republican",
+      "ID": 44
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Democrat",
+      "ID": 45
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 13",
+      "Party": "Democrat",
+      "ID": 46
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 47
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Republican",
+      "ID": 48
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 49
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Republican",
+      "ID": 50
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 51
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Republican",
+      "ID": 52
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 53
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Republican",
+      "ID": 54
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 55
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 56
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Republican",
+      "ID": 57
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Democrat",
+      "ID": 58
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Republican",
+      "ID": 59
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 60
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Republican",
+      "ID": 61
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Democrat",
+      "ID": 62
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23",
+      "Party": "Democrat",
+      "ID": 63
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Party": "Democrat",
+      "ID": 64
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Party": "Democrat",
+      "ID": 65
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Party": "Democrat",
+      "ID": 66
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Party": "Republican",
+      "ID": 67
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27",
+      "Party": "Republican",
+      "ID": 68
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27",
+      "Party": "Democrat",
+      "ID": 69
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 28",
+      "Party": "Republican",
+      "ID": 70
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 28",
+      "Party": "Democrat",
+      "ID": 71
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29",
+      "Party": "Democrat",
+      "ID": 72
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29",
+      "Party": "Republican",
+      "ID": 73
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30",
+      "Party": "Republican",
+      "ID": 74
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30",
+      "Party": "Democrat",
+      "ID": 75
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31",
+      "Party": "Republican",
+      "ID": 76
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31",
+      "Party": "Democrat",
+      "ID": 77
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Democrat",
+      "ID": 78
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Republican",
+      "ID": 79
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Republican",
+      "ID": 80
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Democrat",
+      "ID": 81
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34",
+      "Party": "Democrat",
+      "ID": 82
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34",
+      "Party": "Republican",
+      "ID": 83
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35",
+      "Party": "Republican",
+      "ID": 84
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Party": "Republican",
+      "ID": 85
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Party": "Democrat",
+      "ID": 86
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37",
+      "Party": "Republican",
+      "ID": 87
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37",
+      "Party": "Democrat",
+      "ID": 88
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38",
+      "Party": "Democrat",
+      "ID": 89
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38",
+      "Party": "Republican",
+      "ID": 90
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 91
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Republican",
+      "ID": 92
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 40",
+      "Party": "Democrat",
+      "ID": 93
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41",
+      "Party": "Democrat",
+      "ID": 94
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42",
+      "Party": "Democrat",
+      "ID": 95
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 43",
+      "Party": "Democrat",
+      "ID": 96
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44",
+      "Party": "Republican",
+      "ID": 97
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44",
+      "Party": "Democrat",
+      "ID": 98
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Party": "Democrat",
+      "ID": 99
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Party": "Democrat",
+      "ID": 100
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Party": "Republican",
+      "ID": 101
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47",
+      "Party": "Republican",
+      "ID": 102
+    },
+    {
+      "Name": "State Senator",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47",
+      "Party": "Democrat",
+      "ID": 103
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1A",
+      "Party": "Republican",
+      "ID": 104
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1A",
+      "Party": "Democrat",
+      "ID": 105
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1B",
+      "Party": "Republican",
+      "ID": 106
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1B",
+      "Party": "Democrat",
+      "ID": 107
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1C",
+      "Party": "Republican",
+      "ID": 108
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2A",
+      "Party": "Republican",
+      "ID": 109
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2B",
+      "Party": "Democrat",
+      "ID": 110
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2B",
+      "Party": "Republican",
+      "ID": 111
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3A",
+      "Party": "Democrat",
+      "ID": 112
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3A",
+      "Party": "Republican",
+      "ID": 113
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3B",
+      "Party": "Republican",
+      "ID": 114
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3B",
+      "Party": "Democrat",
+      "ID": 115
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 4",
+      "Party": "Republican",
+      "ID": 116
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 4",
+      "Party": "Democrat",
+      "ID": 117
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 5",
+      "Party": "Republican",
+      "ID": 118
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 5",
+      "Party": "Democrat",
+      "ID": 119
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Party": "Republican",
+      "ID": 120
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Party": "Democrat",
+      "ID": 121
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Democrat",
+      "ID": 122
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Republican",
+      "ID": 123
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Party": "Democrat",
+      "ID": 124
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Party": "Republican",
+      "ID": 125
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9A",
+      "Party": "Republican",
+      "ID": 126
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9A",
+      "Party": "Democrat",
+      "ID": 127
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9B",
+      "Party": "Republican",
+      "ID": 128
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9B",
+      "Party": "Democrat",
+      "ID": 129
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Party": "Republican",
+      "ID": 130
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Party": "Democrat",
+      "ID": 131
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Party": "Democrat",
+      "ID": 132
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Party": "Republican",
+      "ID": 133
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Republican",
+      "ID": 134
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Democrat",
+      "ID": 135
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 13",
+      "Party": "Democrat",
+      "ID": 136
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 13",
+      "Party": "Republican",
+      "ID": 137
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 138
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Republican",
+      "ID": 139
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 140
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Republican",
+      "ID": 141
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 142
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Republican",
+      "ID": 143
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Republican",
+      "ID": 144
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 145
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 146
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Republican",
+      "ID": 147
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 148
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Republican",
+      "ID": 149
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Democrat",
+      "ID": 150
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 151
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Republican",
+      "ID": 152
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Democrat",
+      "ID": 153
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Republican",
+      "ID": 154
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23A",
+      "Party": "Republican",
+      "ID": 155
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23A",
+      "Party": "Democrat",
+      "ID": 156
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23B",
+      "Party": "Democrat",
+      "ID": 157
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Party": "Democrat",
+      "ID": 158
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Party": "Democrat",
+      "ID": 159
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Party": "Democrat",
+      "ID": 160
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27A",
+      "Party": "Democrat",
+      "ID": 161
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27B",
+      "Party": "Democrat",
+      "ID": 162
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27B",
+      "Party": "Republican",
+      "ID": 163
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27C",
+      "Party": "Republican",
+      "ID": 164
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27C",
+      "Party": "Democrat",
+      "ID": 165
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 28",
+      "Party": "Democrat",
+      "ID": 166
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 28",
+      "Party": "Republican",
+      "ID": 167
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29A",
+      "Party": "Republican",
+      "ID": 168
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29A",
+      "Party": "Democrat",
+      "ID": 169
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29B",
+      "Party": "Republican",
+      "ID": 170
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29B",
+      "Party": "Democrat",
+      "ID": 171
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29C",
+      "Party": "Republican",
+      "ID": 172
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29C",
+      "Party": "Democrat",
+      "ID": 173
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30A",
+      "Party": "Republican",
+      "ID": 174
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30A",
+      "Party": "Democrat",
+      "ID": 175
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30B",
+      "Party": "Republican",
+      "ID": 176
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30B",
+      "Party": "Democrat",
+      "ID": 177
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31A",
+      "Party": "Democrat",
+      "ID": 178
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31A",
+      "Party": "Republican",
+      "ID": 179
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31B",
+      "Party": "Republican",
+      "ID": 180
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31B",
+      "Party": "Democrat",
+      "ID": 181
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Democrat",
+      "ID": 182
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Republican",
+      "ID": 183
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Republican",
+      "ID": 184
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Democrat",
+      "ID": 185
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34A",
+      "Party": "Democrat",
+      "ID": 186
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34A",
+      "Party": "Republican",
+      "ID": 187
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34B",
+      "Party": "Democrat",
+      "ID": 188
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34B",
+      "Party": "Republican",
+      "ID": 189
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35A",
+      "Party": "Democrat",
+      "ID": 190
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35A",
+      "Party": "Republican",
+      "ID": 191
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35B",
+      "Party": "Republican",
+      "ID": 192
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35B",
+      "Party": "Democrat",
+      "ID": 193
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Party": "Republican",
+      "ID": 194
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Party": "Democrat",
+      "ID": 195
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Party": "Democrat",
+      "ID": 196
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Party": "Democrat",
+      "ID": 197
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37A",
+      "Party": "Democrat",
+      "ID": 198
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37A",
+      "Party": "Republican",
+      "ID": 199
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37B",
+      "Party": "Republican",
+      "ID": 200
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37B",
+      "Party": "Democrat",
+      "ID": 201
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38A",
+      "Party": "Democrat",
+      "ID": 202
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38A",
+      "Party": "Republican",
+      "ID": 203
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38B",
+      "Party": "Republican",
+      "ID": 204
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38C",
+      "Party": "Republican",
+      "ID": 205
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 206
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Republican",
+      "ID": 207
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 40",
+      "Party": "Democrat",
+      "ID": 208
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41",
+      "Party": "Democrat",
+      "ID": 209
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42A",
+      "Party": "Democrat",
+      "ID": 210
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42A",
+      "Party": "Republican",
+      "ID": 211
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42B",
+      "Party": "Republican",
+      "ID": 212
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42B",
+      "Party": "Democrat",
+      "ID": 213
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 43",
+      "Party": "Democrat",
+      "ID": 214
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44A",
+      "Party": "Democrat",
+      "ID": 215
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44B",
+      "Party": "Democrat",
+      "ID": 216
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Party": "Republican",
+      "ID": 217
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Party": "Democrat",
+      "ID": 218
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Party": "Democrat",
+      "ID": 219
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Party": "Republican",
+      "ID": 220
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47A",
+      "Party": "Democrat",
+      "ID": 221
+    },
+    {
+      "Name": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47B",
+      "Party": "Democrat",
+      "ID": 222
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Republican",
+      "ID": 223
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Democrat",
+      "ID": 224
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Democrat",
+      "ID": 225
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Republican",
+      "ID": 226
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 227
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 228
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 229
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 230
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Republican",
+      "ID": 231
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 232
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Republican",
+      "ID": 233
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 234
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Republican",
+      "ID": 235
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 236
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 237
+    },
+    {
+      "Name": "County Executive",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 238
+    },
+    {
+      "Name": "President of the County Council",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 239
+    },
+    {
+      "Name": "President of the County Council",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 240
+    },
+    {
+      "Name": "County Commissioner President",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Republican",
+      "ID": 241
+    },
+    {
+      "Name": "County Commissioner President",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 242
+    },
+    {
+      "Name": "County Commissioner President",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Democrat",
+      "ID": 243
+    },
+    {
+      "Name": "County Commissioner President",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 244
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 245
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Republican",
+      "ID": 246
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Democrat",
+      "ID": 247
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 248
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 249
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Democrat",
+      "ID": 250
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 251
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Republican",
+      "ID": 252
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 253
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Republican",
+      "ID": 254
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 255
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 256
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Republican",
+      "ID": 257
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 258
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 259
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Republican",
+      "ID": 260
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 261
+    },
+    {
+      "Name": "County Council At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 262
+    },
+    {
+      "Name": "County Commissioner At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 263
+    },
+    {
+      "Name": "County Commissioner At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Democrat",
+      "ID": 264
+    },
+    {
+      "Name": "County Commissioner At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 265
+    },
+    {
+      "Name": "County Commissioner At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Democrat",
+      "ID": 266
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 267
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 268
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 269
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 270
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 271
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 272
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 273
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 274
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 275
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 276
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 277
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 278
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 279
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 280
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 281
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 282
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 283
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 284
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 285
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 286
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 287
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 288
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 289
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 290
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 291
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 292
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 293
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 294
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 295
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 296
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 297
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 298
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 299
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 300
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 301
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 302
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 303
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 304
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 3",
+      "Party": "Democrat",
+      "ID": 305
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 306
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 307
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 308
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 309
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 310
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 311
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 312
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 313
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 314
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 315
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 316
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 317
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 4",
+      "Party": "Democrat",
+      "ID": 318
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 5",
+      "Party": "Democrat",
+      "ID": 319
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 320
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 321
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 5",
+      "Party": "Democrat",
+      "ID": 322
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 323
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 324
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Frederick",
+      "District": "Councilmanic District 5",
+      "Party": "Democrat",
+      "ID": 325
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 326
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Howard",
+      "District": "Councilmanic District 5",
+      "Party": "Democrat",
+      "ID": 327
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Montgomery",
+      "District": "Councilmanic District 5",
+      "Party": "Democrat",
+      "ID": 328
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 5",
+      "Party": "Democrat",
+      "ID": 329
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 330
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 6",
+      "Party": "Republican",
+      "ID": 331
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 6",
+      "Party": "Democrat",
+      "ID": 332
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 6",
+      "Party": "Democrat",
+      "ID": 333
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 6",
+      "Party": "Republican",
+      "ID": 334
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 6",
+      "Party": "Democrat",
+      "ID": 335
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 7",
+      "Party": "Democrat",
+      "ID": 336
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 7",
+      "Party": "Republican",
+      "ID": 337
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 7",
+      "Party": "Democrat",
+      "ID": 338
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 7",
+      "Party": "Republican",
+      "ID": 339
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 7",
+      "Party": "Democrat",
+      "ID": 340
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 8",
+      "Party": "Democrat",
+      "ID": 341
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Prince George's",
+      "District": "Councilmanic District 9",
+      "Party": "Democrat",
+      "ID": 342
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District A",
+      "Party": "Democrat",
+      "ID": 343
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District A",
+      "Party": "Republican",
+      "ID": 344
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District B",
+      "Party": "Republican",
+      "ID": 345
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District B",
+      "Party": "Democrat",
+      "ID": 346
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District C",
+      "Party": "Republican",
+      "ID": 347
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District C",
+      "Party": "Democrat",
+      "ID": 348
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District D",
+      "Party": "Democrat",
+      "ID": 349
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District D",
+      "Party": "Republican",
+      "ID": 350
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District E",
+      "Party": "Republican",
+      "ID": 351
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District E",
+      "Party": "Democrat",
+      "ID": 352
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District F",
+      "Party": "Republican",
+      "ID": 353
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Harford",
+      "District": "Councilmanic District F",
+      "Party": "Democrat",
+      "ID": 354
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 355
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 356
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 357
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 358
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 2",
+      "Party": "Republican",
+      "ID": 359
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 360
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 2",
+      "Party": "Republican",
+      "ID": 361
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 362
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 3",
+      "Party": "Democrat",
+      "ID": 363
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 364
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 365
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 3",
+      "Party": "Democrat",
+      "ID": 366
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 3",
+      "Party": "Democrat",
+      "ID": 367
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 368
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 4",
+      "Party": "Republican",
+      "ID": 369
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 4",
+      "Party": "Democrat",
+      "ID": 370
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 4",
+      "Party": "Democrat",
+      "ID": 371
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 4",
+      "Party": "Republican",
+      "ID": 372
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 4",
+      "Party": "Republican",
+      "ID": 373
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 4",
+      "Party": "Democrat",
+      "ID": 374
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Carroll",
+      "District": "Commissioner District 5",
+      "Party": "Republican",
+      "ID": 375
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 5",
+      "Party": "Democrat",
+      "ID": 376
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Somerset",
+      "District": "Commissioner District 5",
+      "Party": "Republican",
+      "ID": 377
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 5",
+      "Party": "Democrat",
+      "ID": 378
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 5",
+      "Party": "Republican",
+      "ID": 379
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 6",
+      "Party": "Republican",
+      "ID": 380
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 7",
+      "Party": "Republican",
+      "ID": 381
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Party": "Republican",
+      "ID": 382
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Party": "Democrat",
+      "ID": 383
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Party": "Republican",
+      "ID": 384
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Party": "Democrat",
+      "ID": 385
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Party": "Republican",
+      "ID": 386
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Party": "Democrat",
+      "ID": 387
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Party": "Republican",
+      "ID": 388
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Party": "Democrat",
+      "ID": 389
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Party": "Republican",
+      "ID": 390
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Party": "Democrat",
+      "ID": 391
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Party": "Republican",
+      "ID": 392
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Party": "Democrat",
+      "ID": 393
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3",
+      "Party": "Republican",
+      "ID": 394
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3",
+      "Party": "Democrat",
+      "ID": 395
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3",
+      "Party": "Republican",
+      "ID": 396
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3",
+      "Party": "Democrat",
+      "ID": 397
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 4",
+      "Party": "Republican",
+      "ID": 398
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 4",
+      "Party": "Democrat",
+      "ID": 399
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5",
+      "Party": "Republican",
+      "ID": 400
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5",
+      "Party": "Democrat",
+      "ID": 401
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5",
+      "Party": "Republican",
+      "ID": 402
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5",
+      "Party": "Democrat",
+      "ID": 403
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6",
+      "Party": "Republican",
+      "ID": 404
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6",
+      "Party": "Democrat",
+      "ID": 405
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6",
+      "Party": "Republican",
+      "ID": 406
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6",
+      "Party": "Democrat",
+      "ID": 407
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7",
+      "Party": "Republican",
+      "ID": 408
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7",
+      "Party": "Democrat",
+      "ID": 409
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7",
+      "Party": "Republican",
+      "ID": 410
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7",
+      "Party": "Democrat",
+      "ID": 411
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 8",
+      "Party": "Republican",
+      "ID": 412
+    },
+    {
+      "Name": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 8",
+      "Party": "Democrat",
+      "ID": 413
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Cecil",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 414
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Cecil",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 415
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Cecil",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 416
+    },
+    {
+      "Name": "County Council",
+      "Jurisdiction": "Cecil",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 417
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Calvert",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 418
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Calvert",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 419
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Charles",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 420
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Charles",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 421
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Garrett",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 422
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Garrett",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 423
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 424
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 425
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Saint Mary's",
+      "District": "Commissioner District 1",
+      "Party": "Republican",
+      "ID": 426
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Saint Mary's",
+      "District": "Commissioner District 1",
+      "Party": "Democrat",
+      "ID": 427
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Calvert",
+      "District": "Commissioner District 2",
+      "Party": "Republican",
+      "ID": 428
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Calvert",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 429
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Charles",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 430
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Garrett",
+      "District": "Commissioner District 2",
+      "Party": "Republican",
+      "ID": 431
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 432
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 2",
+      "Party": "Republican",
+      "ID": 433
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Saint Mary's",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 434
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Saint Mary's",
+      "District": "Commissioner District 2",
+      "Party": "Republican",
+      "ID": 435
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Calvert",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 436
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Calvert",
+      "District": "Commissioner District 3",
+      "Party": "Democrat",
+      "ID": 437
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Charles",
+      "District": "Commissioner District 3",
+      "Party": "Democrat",
+      "ID": 438
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Garrett",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 439
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 3",
+      "Party": "Democrat",
+      "ID": 440
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 441
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Saint Mary's",
+      "District": "Commissioner District 3",
+      "Party": "Republican",
+      "ID": 442
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Charles",
+      "District": "Commissioner District 4",
+      "Party": "Republican",
+      "ID": 443
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Charles",
+      "District": "Commissioner District 4",
+      "Party": "Democrat",
+      "ID": 444
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 4",
+      "Party": "Democrat",
+      "ID": 445
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 4",
+      "Party": "Republican",
+      "ID": 446
+    },
+    {
+      "Name": "County Commissioner",
+      "Jurisdiction": "Saint Mary's",
+      "District": "Commissioner District 4",
+      "Party": "Republican",
+      "ID": 447
+    },
+    {
+      "Name": "Treasurer",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 448
+    },
+    {
+      "Name": "Treasurer",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 449
+    },
+    {
+      "Name": "Treasurer",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 450
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 451
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Republican",
+      "ID": 452
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Democrat",
+      "ID": 453
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Democrat",
+      "ID": 454
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Democrat",
+      "ID": 455
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 456
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 457
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Republican",
+      "ID": 458
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Republican",
+      "ID": 459
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 460
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Democrat",
+      "ID": 461
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 462
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Republican",
+      "ID": 463
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 464
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 465
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Republican",
+      "ID": 466
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 467
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 468
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Republican",
+      "ID": 469
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 470
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 471
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 472
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 473
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Republican",
+      "ID": 474
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 475
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Republican",
+      "ID": 476
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 477
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 478
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 479
+    },
+    {
+      "Name": "State's Attorney",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Republican",
+      "ID": 480
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 481
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Republican",
+      "ID": 482
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Democrat",
+      "ID": 483
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Democrat",
+      "ID": 484
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Democrat",
+      "ID": 485
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Republican",
+      "ID": 486
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Democrat",
+      "ID": 487
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Democrat",
+      "ID": 488
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 489
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Democrat",
+      "ID": 490
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Republican",
+      "ID": 491
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Republican",
+      "ID": 492
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 493
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Republican",
+      "ID": 494
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 495
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 496
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Republican",
+      "ID": 497
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 498
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 499
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Republican",
+      "ID": 500
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 501
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 502
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 503
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 504
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 505
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 506
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Democrat",
+      "ID": 507
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Democrat",
+      "ID": 508
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Republican",
+      "ID": 509
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 510
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Republican",
+      "ID": 511
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Republican",
+      "ID": 512
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 513
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 514
+    },
+    {
+      "Name": "Clerk of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Republican",
+      "ID": 515
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Democrat",
+      "ID": 516
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 517
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Republican",
+      "ID": 518
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Democrat",
+      "ID": 519
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Democrat",
+      "ID": 520
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Democrat",
+      "ID": 521
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Republican",
+      "ID": 522
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 523
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Democrat",
+      "ID": 524
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 525
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Republican",
+      "ID": 526
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Republican",
+      "ID": 527
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 528
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Democrat",
+      "ID": 529
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Republican",
+      "ID": 530
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 531
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 532
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Republican",
+      "ID": 533
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 534
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 535
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 536
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Republican",
+      "ID": 537
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 538
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Republican",
+      "ID": 539
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 540
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 541
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 542
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 543
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Republican",
+      "ID": 544
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 545
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 546
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 547
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Democrat",
+      "ID": 548
+    },
+    {
+      "Name": "Register of Wills",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Republican",
+      "ID": 549
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 550
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Democrat",
+      "ID": 551
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Republican",
+      "ID": 552
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Democrat",
+      "ID": 553
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Democrat",
+      "ID": 554
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 555
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Democrat",
+      "ID": 556
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 557
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Democrat",
+      "ID": 558
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Republican",
+      "ID": 559
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Republican",
+      "ID": 560
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Democrat",
+      "ID": 561
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 562
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 563
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 564
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Republican",
+      "ID": 565
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 566
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 567
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Republican",
+      "ID": 568
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 569
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 570
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Democrat",
+      "ID": 571
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 572
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Democrat",
+      "ID": 573
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Republican",
+      "ID": 574
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Republican",
+      "ID": 575
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 576
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Republican",
+      "ID": 577
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 578
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 579
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 580
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Republican",
+      "ID": 581
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "Dorchester",
+      "District": "Orphans' Court District 1",
+      "Party": "Democrat",
+      "ID": 582
+    },
+    {
+      "Name": "Judge of the Orphans' Court",
+      "Jurisdiction": "Dorchester",
+      "District": "Orphans' Court District 2",
+      "Party": "Democrat",
+      "ID": 583
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 584
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Democrat",
+      "ID": 585
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Party": "Republican",
+      "ID": 586
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Republican",
+      "ID": 587
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Party": "Democrat",
+      "ID": 588
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Democrat",
+      "ID": 589
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Party": "Republican",
+      "ID": 590
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Democrat",
+      "ID": 591
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 592
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 593
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Democrat",
+      "ID": 594
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Republican",
+      "ID": 595
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Republican",
+      "ID": 596
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 597
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Republican",
+      "ID": 598
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Democrat",
+      "ID": 599
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 600
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 601
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Republican",
+      "ID": 602
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 603
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 604
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Republican",
+      "ID": 605
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 606
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Republican",
+      "ID": 607
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 608
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Republican",
+      "ID": 609
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Party": "Democrat",
+      "ID": 610
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Democrat",
+      "ID": 611
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 612
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 613
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Democrat",
+      "ID": 614
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Democrat",
+      "ID": 615
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Republican",
+      "ID": 616
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 617
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Republican",
+      "ID": 618
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 619
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 620
+    },
+    {
+      "Name": "Sheriff",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Republican",
+      "ID": 621
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Democrat",
+      "ID": 622
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Democrat",
+      "ID": 623
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 2",
+      "Party": "Democrat",
+      "ID": 624
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 4",
+      "Party": "Democrat",
+      "ID": 625
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 5",
+      "Party": "Democrat",
+      "ID": 626
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 6",
+      "Party": "Democrat",
+      "ID": 627
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Worcester",
+      "District": "Commissioner District 7",
+      "Party": "Democrat",
+      "ID": 628
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 1",
+      "Party": "Democrat",
+      "ID": 629
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "Dorchester",
+      "District": "Councilmanic District 2",
+      "Party": "Democrat",
+      "ID": 630
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Democrat",
+      "ID": 631
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 632
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Democrat",
+      "ID": 633
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23",
+      "Party": "Democrat",
+      "ID": 634
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Party": "Democrat",
+      "ID": 635
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Party": "Democrat",
+      "ID": 636
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Party": "Democrat",
+      "ID": 637
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27",
+      "Party": "Democrat",
+      "ID": 638
+    },
+    {
+      "Name": "Democratic Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47",
+      "Party": "Democrat",
+      "ID": 639
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Party": "Democrat",
+      "ID": 640
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Party": "Democrat",
+      "ID": 641
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Democrat",
+      "ID": 642
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Democrat",
+      "ID": 643
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Party": "Democrat",
+      "ID": 644
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Party": "Democrat",
+      "ID": 645
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Party": "Democrat",
+      "ID": 646
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Party": "Democrat",
+      "ID": 647
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Party": "Democrat",
+      "ID": 648
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Party": "Democrat",
+      "ID": 649
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Party": "Democrat",
+      "ID": 650
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Democrat",
+      "ID": 651
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Democrat",
+      "ID": 652
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Party": "Democrat",
+      "ID": 653
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 654
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 655
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 656
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Democrat",
+      "ID": 657
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Democrat",
+      "ID": 658
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23A",
+      "Party": "Democrat",
+      "ID": 659
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23A",
+      "Party": "Democrat",
+      "ID": 660
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23B",
+      "Party": "Democrat",
+      "ID": 661
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23B",
+      "Party": "Democrat",
+      "ID": 662
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Party": "Democrat",
+      "ID": 663
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Party": "Democrat",
+      "ID": 664
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Party": "Democrat",
+      "ID": 665
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Party": "Democrat",
+      "ID": 666
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Party": "Democrat",
+      "ID": 667
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Party": "Democrat",
+      "ID": 668
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27A",
+      "Party": "Democrat",
+      "ID": 669
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27A",
+      "Party": "Democrat",
+      "ID": 670
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27A",
+      "Party": "Democrat",
+      "ID": 671
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27B",
+      "Party": "Democrat",
+      "ID": 672
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27B",
+      "Party": "Democrat",
+      "ID": 673
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27B",
+      "Party": "Democrat",
+      "ID": 674
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 40",
+      "Party": "Democrat",
+      "ID": 675
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 40",
+      "Party": "Democrat",
+      "ID": 676
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41",
+      "Party": "Democrat",
+      "ID": 677
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41",
+      "Party": "Democrat",
+      "ID": 678
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42A",
+      "Party": "Democrat",
+      "ID": 679
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42A",
+      "Party": "Democrat",
+      "ID": 680
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42B",
+      "Party": "Democrat",
+      "ID": 681
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42B",
+      "Party": "Democrat",
+      "ID": 682
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 43",
+      "Party": "Democrat",
+      "ID": 683
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 43",
+      "Party": "Democrat",
+      "ID": 684
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44A",
+      "Party": "Democrat",
+      "ID": 685
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44A",
+      "Party": "Democrat",
+      "ID": 686
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44B",
+      "Party": "Democrat",
+      "ID": 687
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44B",
+      "Party": "Democrat",
+      "ID": 688
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Party": "Democrat",
+      "ID": 689
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Party": "Democrat",
+      "ID": 690
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Party": "Democrat",
+      "ID": 691
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Party": "Democrat",
+      "ID": 692
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47A",
+      "Party": "Democrat",
+      "ID": 693
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47A",
+      "Party": "Democrat",
+      "ID": 694
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47B",
+      "Party": "Democrat",
+      "ID": 695
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47B",
+      "Party": "Democrat",
+      "ID": 696
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Democrat",
+      "ID": 697
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Democrat",
+      "ID": 698
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Democrat",
+      "ID": 699
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Democrat",
+      "ID": 700
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 701
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 702
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Democrat",
+      "ID": 703
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 704
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 705
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 706
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Democrat",
+      "ID": 707
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Democrat",
+      "ID": 708
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Democrat",
+      "ID": 709
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 710
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 711
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 712
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Democrat",
+      "ID": 713
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Democrat",
+      "ID": 714
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Democrat",
+      "ID": 715
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Democrat",
+      "ID": 716
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Democrat",
+      "ID": 717
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Democrat",
+      "ID": 718
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Democrat",
+      "ID": 719
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Democrat",
+      "ID": 720
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Democrat",
+      "ID": 721
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Democrat",
+      "ID": 722
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Democrat",
+      "ID": 723
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Democrat",
+      "ID": 724
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Democrat",
+      "ID": 725
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Democrat",
+      "ID": 726
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Democrat",
+      "ID": 727
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Democrat",
+      "ID": 728
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 729
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 730
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Democrat",
+      "ID": 731
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Democrat",
+      "ID": 732
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Democrat",
+      "ID": 733
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Democrat",
+      "ID": 734
+    },
+    {
+      "Name": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Democrat",
+      "ID": 735
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Republican",
+      "ID": 736
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Party": "Republican",
+      "ID": 737
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Party": "Republican",
+      "ID": 738
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Republican",
+      "ID": 739
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Party": "Republican",
+      "ID": 740
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Republican",
+      "ID": 741
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Party": "Republican",
+      "ID": 742
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Republican",
+      "ID": 743
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Party": "Republican",
+      "ID": 744
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Party": "Republican",
+      "ID": 745
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Republican",
+      "ID": 746
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Party": "Republican",
+      "ID": 747
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Party": "Republican",
+      "ID": 748
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Party": "Republican",
+      "ID": 749
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Party": "Republican",
+      "ID": 750
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Party": "Republican",
+      "ID": 751
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Party": "Republican",
+      "ID": 752
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Party": "Republican",
+      "ID": 753
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Party": "Republican",
+      "ID": 754
+    },
+    {
+      "Name": "Republican Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Republican",
+      "ID": 755
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Republican",
+      "ID": 756
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Republican",
+      "ID": 757
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Republican",
+      "ID": 758
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Republican",
+      "ID": 759
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Republican",
+      "ID": 760
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Republican",
+      "ID": 761
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Republican",
+      "ID": 762
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Republican",
+      "ID": 763
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Republican",
+      "ID": 764
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Republican",
+      "ID": 765
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Republican",
+      "ID": 766
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Republican",
+      "ID": 767
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Republican",
+      "ID": 768
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Republican",
+      "ID": 769
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Republican",
+      "ID": 770
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Republican",
+      "ID": 771
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Party": "Republican",
+      "ID": 772
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Republican",
+      "ID": 773
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Party": "Republican",
+      "ID": 774
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Republican",
+      "ID": 775
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Party": "Republican",
+      "ID": 776
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Republican",
+      "ID": 777
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Party": "Republican",
+      "ID": 778
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Republican",
+      "ID": 779
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Republican",
+      "ID": 780
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 781
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1",
+      "Party": "Republican",
+      "ID": 782
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 783
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 2",
+      "Party": "Republican",
+      "ID": 784
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 785
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3",
+      "Party": "Republican",
+      "ID": 786
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 787
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 4",
+      "Party": "Republican",
+      "ID": 788
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 5",
+      "Party": "Republican",
+      "ID": 789
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 6",
+      "Party": "Republican",
+      "ID": 790
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 6",
+      "Party": "Republican",
+      "ID": 791
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 7",
+      "Party": "Republican",
+      "ID": 792
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 7",
+      "Party": "Republican",
+      "ID": 793
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 8",
+      "Party": "Republican",
+      "ID": 794
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 9",
+      "Party": "Republican",
+      "ID": 795
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 10",
+      "Party": "Republican",
+      "ID": 796
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 11",
+      "Party": "Republican",
+      "ID": 797
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 12",
+      "Party": "Republican",
+      "ID": 798
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 13",
+      "Party": "Republican",
+      "ID": 799
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 14",
+      "Party": "Republican",
+      "ID": 800
+    },
+    {
+      "Name": "Democratic Central Committee Female At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 801
+    },
+    {
+      "Name": "Democratic Central Committee Male At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Democrat",
+      "ID": 802
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 803
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 804
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 805
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 806
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 807
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 808
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 809
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 810
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 811
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 812
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 813
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 814
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Democrat",
+      "ID": 815
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Democrat",
+      "ID": 816
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 817
+    },
+    {
+      "Name": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 818
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 819
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 820
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 821
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 822
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 823
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 824
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 825
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 826
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 827
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 828
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 829
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 830
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Democrat",
+      "ID": 831
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Party": "Democrat",
+      "ID": 832
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 833
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 834
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Party": "Non Partisan",
+      "ID": 835
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Party": "Non Partisan",
+      "ID": 836
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Party": "Non Partisan",
+      "ID": 837
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Party": "Non Partisan",
+      "ID": 838
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Party": "Non Partisan",
+      "ID": 839
+    },
+    {
+      "Name": "Board of Education At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Party": "Non Partisan",
+      "ID": 840
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Montgomery",
+      "District": "Board of Education District 3",
+      "Party": "Non Partisan",
+      "ID": 841
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Queen Anne's",
+      "District": "Commissioner District 2",
+      "Party": "Non Partisan",
+      "ID": 842
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Garrett",
+      "District": "Commissioner District 3",
+      "Party": "Non Partisan",
+      "ID": 843
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Prince George's",
+      "District": "Board of Education District 2",
+      "Party": "Non Partisan",
+      "ID": 844
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Prince George's",
+      "District": "Board of Education District 3",
+      "Party": "Non Partisan",
+      "ID": 845
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Prince George's",
+      "District": "Board of Education District 6",
+      "Party": "Non Partisan",
+      "ID": 846
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Prince George's",
+      "District": "Board of Education District 9",
+      "Party": "Non Partisan",
+      "ID": 847
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 1",
+      "Party": "Non Partisan",
+      "ID": 848
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1",
+      "Party": "Non Partisan",
+      "ID": 849
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 1",
+      "Party": "Non Partisan",
+      "ID": 850
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3",
+      "Party": "Non Partisan",
+      "ID": 851
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 4",
+      "Party": "Non Partisan",
+      "ID": 852
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 4",
+      "Party": "Non Partisan",
+      "ID": 853
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Wicomico",
+      "District": "Councilmanic District 4",
+      "Party": "Non Partisan",
+      "ID": 854
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 5",
+      "Party": "Non Partisan",
+      "ID": 855
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Anne Arundel",
+      "District": "Councilmanic District 7",
+      "Party": "Non Partisan",
+      "ID": 856
+    },
+    {
+      "Name": "Board of Education",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 7",
+      "Party": "Non Partisan",
+      "ID": 857
+    }
+  ]
+}

--- a/data/results.json
+++ b/data/results.json
@@ -4,16 +4,14 @@
   "IsPrimary": true,
   "KeyContests": [
     {
-      "Name": "Governor / Lt. Governor",
+      "Name": "Governor",
       "Jurisdiction": "State of Maryland",
       "District": "State of Maryland",
       "Party": "Democrat",
       "ID": 1
     },
     {
-      "Name": "State's Attorney",
-      "Jurisdiction": "State of Maryland",
-      "District": "Baltimore City",
+      "Name": "Baltimore City State's Attorney",
       "Party": "Democrat",
       "ID": 454
     }

--- a/layouts-robocopy/contest.html
+++ b/layouts-robocopy/contest.html
@@ -1,10 +1,3 @@
-package main
-
-import "html/template"
-
-var templates = template.Must(template.New("name").Parse(`
-
-{{ define "contest" }}
 <table>
     <tr>
         <td>LastUpdate</td>
@@ -43,6 +36,7 @@ var templates = template.Must(template.New("name").Parse(`
         <td>{{ .FullDescription }}</td>
     </tr>
 </table>
+
 <ul>
     {{ range .Options }}
     <li>
@@ -88,6 +82,3 @@ var templates = template.Must(template.New("name").Parse(`
     </li>
     {{ end }}
 </ul>
-{{ end }}
-
-`))

--- a/layouts/results-page/single.html
+++ b/layouts/results-page/single.html
@@ -19,7 +19,9 @@
         data-timeout="30000">
 
         <select class="all-contests js-select2">
-          {{ range .Site.Data.results.AllContests }}
+          <optgroup label="Key Contests">
+          {{ block "optgroup" .Site.Data.results.KeyContests }}
+          {{ range . }}
             <option value="/results/contests/{{ .ID }}.html">
               {{- .Name -}}
               {{- if ne .Jurisdiction "State of Maryland" -}}
@@ -33,6 +35,11 @@
               {{- end -}}
             </option>
           {{ end }}
+          {{ end }}
+          </optgroup>
+          <optgroup label="All Contests">
+          {{ template "optgroup" .Site.Data.results.AllContests }}
+          </optgroup>
         </select>
 
 

--- a/layouts/results-page/single.html
+++ b/layouts/results-page/single.html
@@ -1,0 +1,47 @@
+{{ define "extra-head" }}
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/css/select2.min.css" rel="stylesheet" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.6-rc.0/js/select2.min.js"></script>
+{{ end }}
+
+{{ define "main" }}
+<div class="container">
+    <h1 class="section-header-splash grey">{{.Title}}</h1>
+    <main class="results-page">
+        {{ .Content }}
+    </main>
+
+    {{ partial "ad-leaderboard.html" . }}
+
+    <div
+        class="js-results-container"
+        data-target="#info"
+        data-errors="#errors"
+        data-timeout="30000">
+
+        <select class="all-contests js-select2">
+          {{ range .Site.Data.results.AllContests }}
+            <option value="/results/contests/{{ .ID }}.html">
+              {{- .Name -}}
+              {{- if ne .Jurisdiction "State of Maryland" -}}
+                {{- " " -}}{{- .Jurisdiction -}}
+              {{- end -}}
+              {{- if ne .District "State of Maryland" -}}
+                {{- " " -}}{{- .District -}}
+              {{- end -}}
+              {{- if ne .Party "Non Partisan" -}}
+                {{- " " -}}({{- .Party -}})
+              {{- end -}}
+            </option>
+          {{ end }}
+        </select>
+
+
+        <div id="errors"></div>
+        <div id="info"></div>
+    </div>
+</div>
+
+<!-- googletag.pubads().refresh([gptadslots[0]]) -->
+
+{{ end }}
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "build":
       "yarn run clean && yarn run make-content && yarn run css && yarn run hash-assets && yarn run hugo && yarn run minify && yarn run clean:data",
+    "build:robocopy":
+      "GOPATH=$(mktemp -d) GOBIN=$(pwd) go get -v ./cmd/robocopy",
     "clean":
       "yarn run clean:data && yarn run clean:public && yarn run clean:dist",
     "clean:data": "rm -f data/assets.json",

--- a/static/scripts/javascript.js
+++ b/static/scripts/javascript.js
@@ -395,14 +395,13 @@ var app = {
       xhr.send();
     }
 
-    each("[data-replacement-url]", function(el) {
-      var url = el.getAttribute("data-replacement-url");
+    each(".js-results-container", function(el) {
       var targetEl = el.getAttribute("data-target");
       var errorEl = el.getAttribute("data-errors");
       var timeout = el.getAttribute("data-timeout");
 
-      if (!url || !targetEl || !errorEl || !timeout) {
-        console.warn("data-replacement-url missing requirements");
+      if (!targetEl || !errorEl || !timeout) {
+        console.warn(".js-results-container missing requirements");
         return;
       }
 
@@ -413,27 +412,39 @@ var app = {
         }, timeout);
       }
 
-      el.addEventListener("update", function(ev) {
-        console.log("update started");
-        window.clearTimeout(timeoutID);
-        request(
-          url,
-          function(xhr) {
-            each(targetEl, function(el) {
-              el.innerHTML = xhr.responseText;
-            });
-          },
-          function(e) {
-            each(errorEl, function(el) {
-              el.innerText = "Something went wrong";
-            });
+      el.addEventListener(
+        "update",
+        function(ev) {
+          window.clearTimeout(timeoutID);
+          var url = el.querySelector("select").value;
+          console.log("update started for", url);
 
-            console.error(e);
-          }
-        );
-        setTimer();
-      }, true);
+          request(
+            url,
+            function(xhr) {
+              each(targetEl, function(el) {
+                el.innerHTML = xhr.responseText;
+              });
+            },
+            function(e) {
+              each(errorEl, function(el) {
+                el.innerText = "Something went wrong";
+              });
 
+              console.error(e);
+            }
+          );
+          setTimer();
+        },
+        true
+      );
+
+      el.dispatchEvent(new Event("update"));
+    });
+
+    $(".js-select2").select2();
+    $(".js-select2").on("select2:select", function(e) {
+      var el = e.target.closest(".js-results-container");
       el.dispatchEvent(new Event("update"));
     });
   }

--- a/static/scripts/javascript.js
+++ b/static/scripts/javascript.js
@@ -12,6 +12,7 @@ var app = {
     app.target_links();
     app.toggle_fixed_nav();
     app.party_toggle();
+    app.results_download();
   },
 
   activate_social_buttons: function(socialMessage) {
@@ -353,6 +354,87 @@ var app = {
         $("#choosePartyText").empty();
         $("#choosePartyText").text(party);
       }
+    });
+  },
+
+  results_download: function() {
+    // Simple convenience functions
+    function each(qs, callback) {
+      var nodes = typeof qs === "object" ? qs : document.querySelectorAll(qs);
+      var i;
+      for (i = 0; i < nodes.length; i++) {
+        callback(nodes[i], i);
+      }
+    }
+
+    // function on(qs, etype, callback) {
+    //   var nodes = typeof qs === "object" ? qs : document.querySelectorAll(qs);
+    //   var i;
+    //   for (i = 0; i < nodes.length; i++) {
+    //     nodes[i].addEventListener(etype, callback);
+    //   }
+    // }
+
+    function request(url, success, failure) {
+      var xhr = new XMLHttpRequest();
+      xhr.addEventListener("load", function() {
+        if (xhr.status < 200 || xhr.status > 299) {
+          console.warn("request error", xhr.statusText);
+          xhr.dispatchEvent(new Event("error"));
+          return;
+        }
+        try {
+          success(xhr);
+        } catch (ex) {
+          console.warn("request error", ex);
+          xhr.dispatchEvent(new Event("error"));
+        }
+      });
+      xhr.addEventListener("error", failure);
+      xhr.open("GET", url, true);
+      xhr.send();
+    }
+
+    each("[data-replacement-url]", function(el) {
+      var url = el.getAttribute("data-replacement-url");
+      var targetEl = el.getAttribute("data-target");
+      var errorEl = el.getAttribute("data-errors");
+      var timeout = el.getAttribute("data-timeout");
+
+      if (!url || !targetEl || !errorEl || !timeout) {
+        console.warn("data-replacement-url missing requirements");
+        return;
+      }
+
+      var timeoutID;
+      function setTimer() {
+        timeoutID = window.setTimeout(function() {
+          el.dispatchEvent(new Event("update"));
+        }, timeout);
+      }
+
+      el.addEventListener("update", function(ev) {
+        console.log("update started");
+        window.clearTimeout(timeoutID);
+        request(
+          url,
+          function(xhr) {
+            each(targetEl, function(el) {
+              el.innerHTML = xhr.responseText;
+            });
+          },
+          function(e) {
+            each(errorEl, function(el) {
+              el.innerText = "Something went wrong";
+            });
+
+            console.error(e);
+          }
+        );
+        setTimer();
+      }, true);
+
+      el.dispatchEvent(new Event("update"));
     });
   }
 };


### PR DESCRIPTION
This gets basic robocopy functionality working for local development.

Still todo:

- Handle running in non-local mode, where it will download from BoE every N seconds and upload the files for us.
- Maybe add in some stuff for number of precincts reporting?

Usage:

- Use `yarn run build:robocopy` to create a robocopy executable in your project directory. You can then move it to `~/bin` or something to keep it out of the way but still runnable.
- Make the file `content/results.md` with contents like

```
+++
title = "2018 Primary Results"
type = "results-page"
+++

lorem ipsum
```

This will make the page http://localhost:1313/results/

- That page is based on `layouts/results/single.html`. Change that template to change the basic HTML for the results container page.
- The results page has a list of races for 2018 that it gets from `data/results.json`. If you want, you can change that file manually to change the races listed or regenerate the file by running `robocopy -local -results -output-dir data`. You can use the 2016 races by running `robocopy -local -results -output-dir data -metadata-src cmd/robocopy/test/Metadata.js`.
- The results page has a magic div that the JS looks for called `.js-results-container`. It uses that to figure out what to put into the `#info` box using AJAX. It reports errors downloading into the `#errors` div. It updates console.log when it downloads the page again. As written now, it redownloads the page every 30,000 milliseconds (30s).
- `robocopy` has different options you can change, but the defaults should be fine. Run `robocopy -h` or `robocopy --help` to see the options.
- As written now, you'll always want to use `robocopy` in local mode, so run `robocopy -local`.
- When you run `robocopy -local`, it will download the metadata and results from the board of elections for 2018 and make a bunch of contest pages in `dist/results/contests/{CONTEST-NUMBER}.html`.
- The individual contests are templated by `layouts-robocopy/contests.html`. This template can't use the extra functions normally used by Hugo without more work. Please ask me if you need one of those functions to be added.
- If you want to use the 2016 contest results, run `robocopy -local -metadata-src cmd/robocopy/test/Metadata.js -results-src cmd/robocopy/test/Results.js`.