### PR TITLE
Robocopy: Add dev-server mode, remote upload mode

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,6 +30,9 @@
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
     "service/cloudfront",
+    "service/s3",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
     "service/sts"
   ]
   revision = "a72204b9bf8d48230ee0fe8995613b394c66f2da"
@@ -89,6 +92,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "81ad83d57dcd7905bc4fd68ee5d10951ab612a4a973aef88d578db6d7048ea8f"
+  inputs-digest = "b2fcd4087c3284006fa758110d38424a92769300a5fbc9cb368a48a63fd39244"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -1,21 +1,14 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"html/template"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	humanize "github.com/dustin/go-humanize"
 )
 
 const (
@@ -47,6 +40,7 @@ type Config struct {
 	Bucket           string
 	Path             string
 	PollInterval     time.Duration
+	NumWorkers       int
 }
 
 func FromArgs(args []string) *Config {
@@ -62,6 +56,7 @@ func FromArgs(args []string) *Config {
 	fl.StringVar(&conf.Bucket, "bucket", "elections2018-news-baltimoresun-com", "Amazon S3 bucket")
 	fl.StringVar(&conf.Path, "path", "/results/contests/", "Amazon S3 destination path")
 	fl.DurationVar(&conf.PollInterval, "poll-interval", 30*time.Second, "time between refreshing S3")
+	fl.IntVar(&conf.NumWorkers, "workers", 5, "number of upload workers")
 	fl.Usage = func() {
 		fmt.Fprintf(os.Stderr,
 			`robocopy
@@ -137,79 +132,4 @@ func (c *Config) createFile(t *template.Template, tplname, filename string, data
 	defer deferClose(&err, f.Close)
 
 	return t.ExecuteTemplate(f, tplname, data)
-}
-
-func (c *Config) Remote(m *Metadata, t *template.Template) error {
-	log.Print("connecting to AWS")
-	s, err := session.NewSession(&aws.Config{
-		Region: aws.String(c.Region),
-	})
-	if err != nil {
-		return fmt.Errorf("bad AWS credentials: %v", err)
-	}
-	var cl = client{
-		uploader: s3manager.NewUploader(s),
-		cachecontrol: aws.String(
-			fmt.Sprintf("public, max-age=%.0f", c.PollInterval.Seconds()),
-		),
-		template: t,
-	}
-
-	for range time.Tick(c.PollInterval) {
-		r, err := ResultsContainerFrom(c.ResultsLocation)
-		if err != nil {
-			log.Printf("results error: %v", err)
-			continue
-		}
-
-		log.Print("processing and uploading results")
-		cr := MapContestResults(m, r)
-		for cid, rp := range cr {
-			filename := fmt.Sprintf("%d.html", cid)
-			err = c.uploadFile(cl, filename, rp)
-			if err != nil {
-				return err
-			}
-		}
-		log.Print("finished uploading")
-	}
-	panic("unreachable")
-}
-
-var funcMap = map[string]interface{}{
-	"commas": func(i int) string { return humanize.Comma(int64(i)) },
-}
-
-func (c *Config) template() (*template.Template, error) {
-	t, err := template.New("").Funcs(funcMap).ParseGlob(c.TemplateGlob)
-	if err != nil {
-		return nil, fmt.Errorf("could not load templates from %s: %v", c.TemplateGlob, err)
-	}
-	return t, err
-}
-
-type client struct {
-	uploader     *s3manager.Uploader
-	template     *template.Template
-	cachecontrol *string
-}
-
-func (c *Config) uploadFile(cl client, filename string, data interface{}) error {
-	var buf bytes.Buffer
-	err := cl.template.ExecuteTemplate(&buf, "contest.html", data)
-	if err != nil {
-		return fmt.Errorf("error executing template: %v", err)
-	}
-
-	_, err = cl.uploader.Upload(&s3manager.UploadInput{
-		Bucket:       aws.String(c.Bucket),
-		Key:          aws.String(c.Path + filename),
-		ContentType:  aws.String("text/html; charset=utf-8"),
-		CacheControl: cl.cachecontrol,
-		Body:         &buf,
-	})
-	if err != nil {
-		log.Printf("error uploading %s: %v", filename, err)
-	}
-	return nil
 }

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -1,15 +1,20 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	humanize "github.com/dustin/go-humanize"
 )
 
@@ -38,6 +43,10 @@ type Config struct {
 	ResultsLocation  string
 	OutputDir        string
 	TemplateGlob     string
+	Region           string
+	Bucket           string
+	Path             string
+	PollInterval     time.Duration
 }
 
 func FromArgs(args []string) *Config {
@@ -49,6 +58,10 @@ func FromArgs(args []string) *Config {
 	fl.StringVar(&conf.ResultsLocation, "results-src", results18url, "url or filename for results")
 	fl.StringVar(&conf.OutputDir, "output-dir", "dist/results/contests", "directory to save into")
 	fl.StringVar(&conf.TemplateGlob, "template-glob", "layouts-robocopy/*.html", "pattern to look for templates with")
+	fl.StringVar(&conf.Region, "region", "us-east-1", "Amazon region for S3")
+	fl.StringVar(&conf.Bucket, "bucket", "elections2018-news-baltimoresun-com", "Amazon S3 bucket")
+	fl.StringVar(&conf.Path, "path", "/results/contests/", "Amazon S3 destination path")
+	fl.DurationVar(&conf.PollInterval, "poll-interval", 30*time.Second, "time between refreshing S3")
 	fl.Usage = func() {
 		fmt.Fprintf(os.Stderr,
 			`robocopy
@@ -65,21 +78,17 @@ Usage of robocopy:
 }
 
 func (c *Config) Exec() error {
-	if !c.Local {
-		return fmt.Errorf("not implemented")
-	}
-
-	var funcMap = map[string]interface{}{
-		"commas": func(i int) string { return humanize.Comma(int64(i)) },
-	}
-	t, err := template.New("").Funcs(funcMap).ParseGlob(c.TemplateGlob)
+	t, err := c.template()
 	if err != nil {
-		return fmt.Errorf("could not load templates from %s: %v", c.TemplateGlob, err)
+		return err
 	}
-
 	m, err := MetadataFrom(c.MetadataLocation)
 	if err != nil {
 		return err
+	}
+
+	if !c.Local {
+		return c.Remote(m, t)
 	}
 
 	if c.CreateResults {
@@ -128,4 +137,77 @@ func (c *Config) createFile(t *template.Template, tplname, filename string, data
 	defer deferClose(&err, f.Close)
 
 	return t.ExecuteTemplate(f, tplname, data)
+}
+
+func (c *Config) Remote(m *Metadata, t *template.Template) error {
+	s, err := session.NewSession(&aws.Config{
+		Region: aws.String(c.Region),
+	})
+	if err != nil {
+		return fmt.Errorf("bad AWS credentials: %v", err)
+	}
+	var cl = client{
+		uploader: s3manager.NewUploader(s),
+		cachecontrol: aws.String(
+			fmt.Sprintf("public, max-age=%.0f", c.PollInterval.Seconds()),
+		),
+		template: t,
+	}
+
+	for range time.Tick(c.PollInterval) {
+		log.Print("getting results")
+		r, err := ResultsContainerFrom(c.ResultsLocation)
+		if err != nil {
+			log.Printf("results error: %v", err)
+			continue
+		}
+
+		cr := MapContestResults(m, r)
+		for cid, rp := range cr {
+			filename := fmt.Sprintf("%d.html", cid)
+			err = c.uploadFile(cl, filename, rp)
+			if err != nil {
+				return err
+			}
+		}
+		log.Print("finished uploading")
+	}
+	panic("unreachable")
+}
+
+var funcMap = map[string]interface{}{
+	"commas": func(i int) string { return humanize.Comma(int64(i)) },
+}
+
+func (c *Config) template() (*template.Template, error) {
+	t, err := template.New("").Funcs(funcMap).ParseGlob(c.TemplateGlob)
+	if err != nil {
+		return nil, fmt.Errorf("could not load templates from %s: %v", c.TemplateGlob, err)
+	}
+	return t, err
+}
+
+type client struct {
+	uploader     *s3manager.Uploader
+	template     *template.Template
+	cachecontrol *string
+}
+
+func (c *Config) uploadFile(cl client, filename string, data interface{}) error {
+	var buf bytes.Buffer
+	err := cl.template.ExecuteTemplate(&buf, "contest.html", data)
+	if err != nil {
+		return fmt.Errorf("error executing template: %v", err)
+	}
+
+	_, err = cl.uploader.Upload(&s3manager.UploadInput{
+		Bucket:       aws.String(c.Bucket),
+		Key:          aws.String(c.Path + filename),
+		CacheControl: cl.cachecontrol,
+		Body:         &buf,
+	})
+	if err != nil {
+		log.Printf("error uploading %s: %v", filename, err)
+	}
+	return nil
 }

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -73,6 +73,13 @@ Usage of robocopy:
 }
 
 func (c *Config) Exec() error {
+	if !c.Local {
+		return c.RemoteExec()
+	}
+	return c.LocalExec()
+}
+
+func (c *Config) LocalExec() error {
 	t, err := c.template()
 	if err != nil {
 		return err
@@ -80,10 +87,6 @@ func (c *Config) Exec() error {
 	m, err := MetadataFrom(c.MetadataLocation)
 	if err != nil {
 		return err
-	}
-
-	if !c.Local {
-		return c.Remote(m, t)
 	}
 
 	if c.CreateResults {

--- a/cmd/robocopy/server.go
+++ b/cmd/robocopy/server.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (c *Config) Serve() error {
+	port := fmt.Sprintf(":%d", c.DevPort)
+
+	// subscribe to SIGINT signals
+	stopChan := make(chan os.Signal, 1)
+	signal.Notify(stopChan, os.Interrupt)
+
+	http.Handle(c.Path, http.StripPrefix(c.Path, http.HandlerFunc(c.devServer)))
+	srv := &http.Server{Addr: port}
+	go func() {
+		<-stopChan // wait for system signal
+		log.Println("Shutting down server...")
+
+		// shut down gracefully, but wait no longer than 5 seconds before halting
+		ctx, c := context.WithTimeout(context.Background(), 5*time.Second)
+		defer c()
+		srv.Shutdown(ctx)
+	}()
+
+	log.Printf("Serving http://localhost:%d%s", c.DevPort, c.Path)
+	return srv.ListenAndServe()
+}
+
+func (c *Config) devServer(w http.ResponseWriter, r *http.Request) {
+	log.Printf("%s %q", r.Method, r.URL.Path)
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "max-age=0")
+
+	if !strings.HasSuffix(r.URL.Path, ".html") {
+		http.NotFound(w, r)
+		return
+	}
+	if err := c.handleRequest(w, r); err != nil {
+		log.Printf("error: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	log.Println("OK")
+}
+
+func (c *Config) handleRequest(w http.ResponseWriter, r *http.Request) error {
+	id, err := strconv.Atoi(strings.TrimSuffix(r.URL.Path, ".html"))
+	if err != nil {
+		return fmt.Errorf("invalid contest id: %v", err)
+	}
+	cid := ContestID(id)
+
+	t, err := c.template()
+	if err != nil {
+		return err
+	}
+	m, err := MetadataFrom(c.MetadataLocation)
+	if err != nil {
+		return err
+	}
+
+	rc, err := ResultsContainerFrom(c.ResultsLocation)
+	if err != nil {
+		return err
+	}
+
+	cr := MapContestResults(m, rc)
+	data, ok := cr[cid]
+	if !ok {
+		return fmt.Errorf("no such contest: %d", cid)
+	}
+
+	return t.ExecuteTemplate(w, "contest.html", data)
+}

--- a/cmd/robocopy/uploader.go
+++ b/cmd/robocopy/uploader.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	humanize "github.com/dustin/go-humanize"
+)
+
+type client struct {
+	uploader     *s3manager.Uploader
+	template     *template.Template
+	cachecontrol *string
+	metadata     *Metadata
+}
+
+func (c *Config) Remote(m *Metadata, t *template.Template) error {
+	log.Print("connecting to AWS")
+	s, err := session.NewSession(&aws.Config{
+		Region: aws.String(c.Region),
+	})
+	if err != nil {
+		return fmt.Errorf("bad AWS credentials: %v", err)
+	}
+	var cl = client{
+		uploader: s3manager.NewUploader(s),
+		cachecontrol: aws.String(
+			fmt.Sprintf("public, max-age=%.0f", c.PollInterval.Seconds()),
+		),
+		template: t,
+		metadata: m,
+	}
+
+	for range time.Tick(c.PollInterval) {
+		if err = c.RemoteTick(cl); err != nil {
+			log.Printf("had errors: %v", err)
+		} else {
+			log.Print("finished uploading")
+		}
+	}
+	panic("unreachable")
+}
+
+func (c *Config) RemoteTick(cl client) error {
+	var (
+		funcCh     = make(chan func() error, c.NumWorkers)
+		errCh      = make(chan error, c.NumWorkers)
+		waitingFor int
+	)
+
+	for i := 0; i < c.NumWorkers; i++ {
+		go func() {
+			for f := range funcCh {
+				errCh <- f()
+			}
+		}()
+	}
+
+	r, err := ResultsContainerFrom(c.ResultsLocation)
+	if err != nil {
+		return err
+	}
+
+	log.Print("processing and uploading results")
+	cr := MapContestResults(cl.metadata, r)
+	// make a queue of cids
+	cids := make([]ContestID, 0, len(cr))
+	for cid := range cr {
+		cids = append(cids, cid)
+	}
+
+	log.Printf("received %d items", len(cids))
+
+	// loop through and pop off cids until they're all gone
+	var (
+		loops  int
+		hadErr error
+	)
+	for len(cids) > 0 || waitingFor > 0 {
+		var (
+			taskCh chan func() error
+			task   func() error
+		)
+		if len(cids) > 0 {
+			cid := cids[0]
+			rp := cr[cid]
+			filename := fmt.Sprintf("%d.html", cid)
+			taskCh = funcCh
+			task = func() error { return c.uploadFile(cl, filename, rp) }
+		}
+
+		select {
+		case taskCh <- task:
+			waitingFor++
+			cids = cids[1:]
+		case err := <-errCh:
+			loops++
+			waitingFor--
+			if err != nil && hadErr == nil {
+				hadErr = err
+				cids = nil // Just give up for now
+			}
+		}
+	}
+	log.Printf("handled %d items", loops)
+	return hadErr
+}
+
+var funcMap = map[string]interface{}{
+	"commas": func(i int) string { return humanize.Comma(int64(i)) },
+}
+
+func (c *Config) template() (*template.Template, error) {
+	t, err := template.New("").Funcs(funcMap).ParseGlob(c.TemplateGlob)
+	if err != nil {
+		return nil, fmt.Errorf("could not load templates from %s: %v", c.TemplateGlob, err)
+	}
+	return t, err
+}
+
+var pool sync.Pool
+
+func (c *Config) uploadFile(cl client, filename string, data interface{}) error {
+	var buf = &bytes.Buffer{}
+	err := cl.template.ExecuteTemplate(buf, "contest.html", data)
+	if err != nil {
+		return fmt.Errorf("error executing template: %v", err)
+	}
+
+	_, err = cl.uploader.Upload(&s3manager.UploadInput{
+		Bucket:       aws.String(c.Bucket),
+		Key:          aws.String(c.Path + filename),
+		ContentType:  aws.String("text/html; charset=utf-8"),
+		CacheControl: cl.cachecontrol,
+		Body:         buf,
+	})
+	if err != nil {
+		log.Printf("error uploading %s: %v", filename, err)
+	}
+	return err
+}

--- a/cmd/robocopy/utils.go
+++ b/cmd/robocopy/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -24,6 +25,7 @@ func deferClose(err *error, f func() error) {
 }
 
 func readFrom(name string) (rc io.ReadCloser, err error) {
+	log.Printf("preparing to get %q", name)
 	if strings.HasPrefix(name, "http") {
 		rsp, err := http.Get(name)
 		return rsp.Body, err

--- a/cmd/robocopy/utils.go
+++ b/cmd/robocopy/utils.go
@@ -28,7 +28,10 @@ func readFrom(name string) (rc io.ReadCloser, err error) {
 	log.Printf("preparing to get %q", name)
 	if strings.HasPrefix(name, "http") {
 		rsp, err := http.Get(name)
-		return rsp.Body, err
+		if err != nil {
+			return nil, err
+		}
+		return rsp.Body, nil
 	}
 
 	f, err := os.Open(name)

--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,7 @@ image = "images/voter-guide-square.png"
 omniture-page-name = "bs:newsserver:elections2018:news:maryland:politics:voter-guide-2018:dataproject"
 omniture-channel = "news:maryland:politics"
 omniture-server = "elections2018.news.baltimoresun.com"
+results-base-url = "/results/contests/"
 Year = 2018
 
 

--- a/layouts/results-page/single.html
+++ b/layouts/results-page/single.html
@@ -20,25 +20,28 @@
 
         <select class="all-contests js-select2">
           <optgroup label="Key Contests">
-          {{ block "optgroup" .Site.Data.results.KeyContests }}
-          {{ range . }}
-            <option value="/results/contests/{{ .ID }}.html">
-              {{- .Name -}}
-              {{- if ne .Jurisdiction "State of Maryland" -}}
-                {{- " " -}}{{- .Jurisdiction -}}
-              {{- end -}}
-              {{- if ne .District "State of Maryland" -}}
-                {{- " " -}}{{- .District -}}
-              {{- end -}}
-              {{- if ne .Party "Non Partisan" -}}
-                {{- " " -}}({{- .Party -}})
-              {{- end -}}
-            </option>
-          {{ end }}
+          {{ .Scratch.Set "contests" .Site.Data.results.KeyContests }}
+          {{ block "optgroup" . }}
+            {{ $baseURL := .Param "results-base-url" }}
+            {{ range .Scratch.Get "contests" }}
+              <option value='{{ $baseURL }}{{ .ID }}.html'>
+                {{- .Name -}}
+                {{- if ne .Jurisdiction "State of Maryland" -}}
+                  {{- " " -}}{{- .Jurisdiction -}}
+                {{- end -}}
+                {{- if ne .District "State of Maryland" -}}
+                  {{- " " -}}{{- .District -}}
+                {{- end -}}
+                {{- if ne .Party "Non Partisan" -}}
+                  {{- " " -}}({{- .Party -}})
+                {{- end -}}
+              </option>
+            {{ end }}
           {{ end }}
           </optgroup>
           <optgroup label="All Contests">
-          {{ template "optgroup" .Site.Data.results.AllContests }}
+          {{ .Scratch.Set "contests" .Site.Data.results.AllContests }}
+          {{ template "optgroup" . }}
           </optgroup>
         </select>
 


### PR DESCRIPTION
To use remote server mode, re-build and install robocopy, then run `robocopy -dev-server` to start the dev server. (You can also change the data source with the same options as in local mode.) Change `results.md` to tell it to use the new server:

```
+++
title = "2018 Primary Results"
type = "results-page"
results-base-url = "http://localhost:9191/results/contests/"
+++

lorem ipsum
```

Remove `results-base-url` from the front-matter if you want to go back to testing in local-mode.