### PR TITLE
Content: Add results page as a draft

### DIFF
--- a/content/results.md
+++ b/content/results.md
@@ -1,0 +1,8 @@
++++
+title = "2018 Primary Election Results"
+type = "results-page"
+results-base-url = "http://localhost:9191/results/contests/"
+draft = true
++++
+
+From June 14 to June 21, Marylanders will be able to participate in early voting for the 2018 Primary Election. Tuesday, June 26 is the day of the primary election. Lorem ipsum, blah blah…

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format": "prettier --write '**/*.{js,json,scss}'",
     "make-content": "./make-content.sh",
     "minify": "minify -r -o public public",
-    "server": "hugo serve",
+    "server": "hugo serve --buildDrafts",
     "test": "yarn run test:eslint && yarn run test:prettier",
     "test:eslint": "eslint static/scripts/javascript.js --fix",
     "test:prettier": "prettier -l '**/*.{js,json,scss}'"


### PR DESCRIPTION
If we use Hugo's drafts feature, we can commit results.md without accidentally publishing it early.