### PR TITLE
Robocopy: Add district results pages

### DIFF
--- a/cmd/robocopy/controller.go
+++ b/cmd/robocopy/controller.go
@@ -219,3 +219,19 @@ func MapContestResults(m *Metadata, rc *ResultsContainer) map[ContestID]*Result 
 	}
 	return contests
 }
+
+func MapDistrictResults(m *Metadata, contests map[ContestID]*Result) map[DistrictID][]*Result {
+	districts := make(map[DistrictID][]*Result)
+	// Go through all the data and map out the districts
+	for cid, result := range contests {
+		did := m.Contests[cid].District
+		districts[did] = append(districts[did], result)
+	}
+	// Sort the districts by contest name
+	for _, results := range districts {
+		sort.Slice(results, func(i, j int) bool {
+			return results[i].Contest < results[j].Contest
+		})
+	}
+	return districts
+}

--- a/cmd/robocopy/json.go
+++ b/cmd/robocopy/json.go
@@ -299,12 +299,19 @@ func (m *Metadata) MarshalJSON() (b []byte, err error) {
 		Jurisdiction string
 		District     string
 	}
+	type districtReturnJSON struct {
+		ID           string
+		Jurisdiction string
+		District     string
+		Type         string
+	}
 	type metadataReturnJSON struct {
 		ElectionDate *time.Time
 		ElectionType *string
 		IsPrimary    *bool
 		AllContests  []raceReturnJSON
 		AllOptions   []optionReturnJSON
+		AllDistricts []districtReturnJSON
 	}
 	var r = metadataReturnJSON{
 		ElectionDate: &m.ElectionDate,
@@ -348,6 +355,19 @@ func (m *Metadata) MarshalJSON() (b []byte, err error) {
 	}
 	sort.Slice(r.AllOptions, func(i, j int) bool {
 		return LowerAlpha(r.AllOptions[i].Name) < LowerAlpha(r.AllOptions[j].Name)
+	})
+
+	r.AllDistricts = make([]districtReturnJSON, 0, len(m.Districts))
+	for did, dist := range m.Districts {
+		r.AllDistricts = append(r.AllDistricts, districtReturnJSON{
+			ID:           fmt.Sprintf("%d", did),
+			Jurisdiction: dist.Parent.From(m).Name,
+			District:     dist.Name,
+			Type:         dist.Type.From(m).Description,
+		})
+	}
+	sort.Slice(r.AllDistricts, func(i, j int) bool {
+		return LowerAlpha(r.AllDistricts[i].District) < LowerAlpha(r.AllDistricts[j].District)
 	})
 	return json.Marshal(&r)
 }

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -62,7 +62,7 @@ func FromArgs(args []string) *Config {
 	fl.StringVar(&conf.TemplateGlob, "template-glob", "layouts-robocopy/*.html", "pattern to look for templates with")
 	fl.StringVar(&conf.Region, "region", "us-east-1", "Amazon region for S3")
 	fl.StringVar(&conf.Bucket, "bucket", "elections2018-news-baltimoresun-com", "Amazon S3 bucket")
-	fl.StringVar(&conf.Path, "path", "/results/contests/", "Amazon S3 destination path")
+	fl.StringVar(&conf.Path, "path", "/results/", "Amazon S3 destination path")
 	fl.DurationVar(&conf.PollInterval, "poll-interval", 30*time.Second, "time between refreshing S3")
 	fl.IntVar(&conf.DevPort, "dev-port", 9191, "port for dev server")
 	fl.IntVar(&conf.NumWorkers, "workers", 5, "number of upload workers")

--- a/cmd/robocopy/server.go
+++ b/cmd/robocopy/server.go
@@ -19,8 +19,7 @@ func (c *Config) Serve() error {
 	stopChan := make(chan os.Signal, 1)
 	signal.Notify(stopChan, os.Interrupt)
 
-	http.Handle(c.Path, http.StripPrefix(c.Path, http.HandlerFunc(c.devServer)))
-	srv := &http.Server{Addr: port}
+	srv := &http.Server{Addr: port, Handler: c.Routes()}
 	go func() {
 		<-stopChan // wait for system signal
 		log.Println("Shutting down server...")
@@ -35,25 +34,38 @@ func (c *Config) Serve() error {
 	return srv.ListenAndServe()
 }
 
-func (c *Config) devServer(w http.ResponseWriter, r *http.Request) {
-	log.Printf("%s %q", r.Method, r.URL.Path)
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Cache-Control", "max-age=0")
+func (c *Config) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle(c.Path+"contests/", http.StripPrefix(c.Path+"contests/",
+		c.stdMiddleware(c.handleContests)))
+	mux.Handle(c.Path+"districts/", http.StripPrefix(c.Path+"districts/",
+		c.stdMiddleware(c.handleDistricts)))
+	return mux
+}
 
-	if !strings.HasSuffix(r.URL.Path, ".html") {
-		http.NotFound(w, r)
-		return
-	}
-	if err := c.handleRequest(w, r); err != nil {
-		status := http.StatusInternalServerError
-		if s, ok := err.(interface{ Status() int }); ok {
-			status = s.Status()
+type erroringHandler = func(w http.ResponseWriter, r *http.Request) error
+
+func (c *Config) stdMiddleware(h erroringHandler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %q", r.Method, r.URL.Path)
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Cache-Control", "max-age=0")
+
+		if !strings.HasSuffix(r.URL.Path, ".html") {
+			http.NotFound(w, r)
+			return
 		}
-		log.Printf("error: %v", err)
-		http.Error(w, err.Error(), status)
-		return
-	}
-	log.Println("OK")
+		if err := h(w, r); err != nil {
+			status := http.StatusInternalServerError
+			if s, ok := err.(interface{ Status() int }); ok {
+				status = s.Status()
+			}
+			log.Printf("error: %v", err)
+			http.Error(w, err.Error(), status)
+			return
+		}
+		log.Println("OK")
+	})
 }
 
 type statusError int
@@ -66,7 +78,7 @@ func (s statusError) Status() int {
 	return int(s)
 }
 
-func (c *Config) handleRequest(w http.ResponseWriter, r *http.Request) error {
+func (c *Config) handleContests(w http.ResponseWriter, r *http.Request) error {
 	id, err := strconv.Atoi(strings.TrimSuffix(r.URL.Path, ".html"))
 	if err != nil {
 		return statusError(http.StatusNotFound)
@@ -94,6 +106,42 @@ func (c *Config) handleRequest(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	err = t.ExecuteTemplate(w, "contest.html", data)
+	if err != nil {
+		// too late to return 500
+		log.Printf("error executing template: %v", err)
+	}
+	return nil
+}
+
+func (c *Config) handleDistricts(w http.ResponseWriter, r *http.Request) error {
+	id, err := strconv.Atoi(strings.TrimSuffix(r.URL.Path, ".html"))
+	if err != nil {
+		return statusError(http.StatusNotFound)
+	}
+	did := DistrictID(id)
+
+	t, err := c.template()
+	if err != nil {
+		return err
+	}
+	m, err := MetadataFrom(c.MetadataLocation)
+	if err != nil {
+		return err
+	}
+
+	rc, err := ResultsContainerFrom(c.ResultsLocation)
+	if err != nil {
+		return err
+	}
+
+	cr := MapContestResults(m, rc)
+	dr := MapDistrictResults(m, cr)
+	data, ok := dr[did]
+	if !ok {
+		return statusError(http.StatusNotFound)
+	}
+
+	err = t.ExecuteTemplate(w, "district.html", data)
 	if err != nil {
 		// too late to return 500
 		log.Printf("error executing template: %v", err)

--- a/content/results.md
+++ b/content/results.md
@@ -1,7 +1,7 @@
 +++
 title = "2018 Primary Election Results"
 type = "results-page"
-results-base-url = "http://localhost:9191/results/contests/"
+results-base-url = "http://localhost:9191/results/"
 draft = true
 +++
 

--- a/data/results.json
+++ b/data/results.json
@@ -4493,1115 +4493,1066 @@
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 7",
+      "District": "Legislative District 8",
       "Party": "Democrat",
       "ID": 642
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 8",
+      "District": "Legislative District 10",
       "Party": "Democrat",
       "ID": 643
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 10",
+      "District": "Legislative District 11",
       "Party": "Democrat",
       "ID": 644
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 11",
+      "District": "Legislative District 12",
       "Party": "Democrat",
       "ID": 645
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 12",
+      "District": "Legislative District 21",
       "Party": "Democrat",
       "ID": 646
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 12",
+      "District": "Legislative District 22",
       "Party": "Democrat",
       "ID": 647
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21",
+      "District": "Legislative District 23A",
       "Party": "Democrat",
       "ID": 648
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21",
+      "District": "Legislative District 23B",
       "Party": "Democrat",
       "ID": 649
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 22",
+      "District": "Legislative District 24",
       "Party": "Democrat",
       "ID": 650
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 23A",
+      "District": "Legislative District 25",
       "Party": "Democrat",
       "ID": 651
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 23B",
+      "District": "Legislative District 26",
       "Party": "Democrat",
       "ID": 652
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 24",
+      "District": "Legislative District 27A",
       "Party": "Democrat",
       "ID": 653
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 25",
+      "District": "Legislative District 27B",
       "Party": "Democrat",
       "ID": 654
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 26",
+      "District": "Legislative District 40",
       "Party": "Democrat",
       "ID": 655
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27A",
+      "District": "Legislative District 41",
       "Party": "Democrat",
       "ID": 656
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27A",
+      "District": "Legislative District 42A",
       "Party": "Democrat",
       "ID": 657
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27B",
+      "District": "Legislative District 42B",
       "Party": "Democrat",
       "ID": 658
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27B",
+      "District": "Legislative District 43",
       "Party": "Democrat",
       "ID": 659
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 40",
+      "District": "Legislative District 44A",
       "Party": "Democrat",
       "ID": 660
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 41",
+      "District": "Legislative District 44B",
       "Party": "Democrat",
       "ID": 661
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 42A",
+      "District": "Legislative District 45",
       "Party": "Democrat",
       "ID": 662
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 42B",
+      "District": "Legislative District 46",
       "Party": "Democrat",
       "ID": 663
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 43",
+      "District": "Legislative District 47A",
       "Party": "Democrat",
       "ID": 664
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 44A",
+      "District": "Legislative District 47B",
       "Party": "Democrat",
       "ID": 665
     },
     {
-      "Name": "Democratic Central Committee",
+      "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 44B",
+      "District": "Allegany County",
       "Party": "Democrat",
       "ID": 666
     },
     {
-      "Name": "Democratic Central Committee",
+      "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 45",
+      "District": "Caroline County",
       "Party": "Democrat",
       "ID": 667
     },
     {
-      "Name": "Democratic Central Committee",
+      "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 46",
+      "District": "Carroll County",
       "Party": "Democrat",
       "ID": 668
     },
     {
-      "Name": "Democratic Central Committee",
+      "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 47A",
+      "District": "Cecil County",
       "Party": "Democrat",
       "ID": 669
     },
     {
-      "Name": "Democratic Central Committee",
+      "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 47B",
+      "District": "Charles County",
       "Party": "Democrat",
       "ID": 670
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Allegany County",
+      "District": "Frederick County",
       "Party": "Democrat",
       "ID": 671
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Caroline County",
+      "District": "Garrett County",
       "Party": "Democrat",
       "ID": 672
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Carroll County",
+      "District": "Harford County",
       "Party": "Democrat",
       "ID": 673
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Cecil County",
+      "District": "Howard County",
       "Party": "Democrat",
       "ID": 674
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Charles County",
+      "District": "Kent County",
       "Party": "Democrat",
       "ID": 675
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Frederick County",
+      "District": "Queen Anne's County",
       "Party": "Democrat",
       "ID": 676
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Garrett County",
+      "District": "Saint Mary's County",
       "Party": "Democrat",
       "ID": 677
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Harford County",
+      "District": "Somerset County",
       "Party": "Democrat",
       "ID": 678
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Howard County",
+      "District": "Talbot County",
       "Party": "Democrat",
       "ID": 679
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Kent County",
+      "District": "Washington County",
       "Party": "Democrat",
       "ID": 680
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
-      "District": "Queen Anne's County",
+      "District": "Wicomico County",
       "Party": "Democrat",
       "ID": 681
     },
     {
-      "Name": "Democratic Central Committee Female",
+      "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Saint Mary's County",
+      "District": "Allegany County",
       "Party": "Democrat",
       "ID": 682
     },
     {
-      "Name": "Democratic Central Committee Female",
+      "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Somerset County",
+      "District": "Caroline County",
       "Party": "Democrat",
       "ID": 683
     },
     {
-      "Name": "Democratic Central Committee Female",
+      "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Talbot County",
+      "District": "Carroll County",
       "Party": "Democrat",
       "ID": 684
     },
     {
-      "Name": "Democratic Central Committee Female",
+      "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Washington County",
+      "District": "Cecil County",
       "Party": "Democrat",
       "ID": 685
     },
     {
-      "Name": "Democratic Central Committee Female",
+      "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Wicomico County",
+      "District": "Charles County",
       "Party": "Democrat",
       "ID": 686
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Allegany County",
+      "District": "Frederick County",
       "Party": "Democrat",
       "ID": 687
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Caroline County",
+      "District": "Garrett County",
       "Party": "Democrat",
       "ID": 688
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Carroll County",
+      "District": "Harford County",
       "Party": "Democrat",
       "ID": 689
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Cecil County",
+      "District": "Howard County",
       "Party": "Democrat",
       "ID": 690
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Charles County",
+      "District": "Kent County",
       "Party": "Democrat",
       "ID": 691
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Frederick County",
+      "District": "Queen Anne's County",
       "Party": "Democrat",
       "ID": 692
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Garrett County",
+      "District": "Saint Mary's County",
       "Party": "Democrat",
       "ID": 693
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Harford County",
+      "District": "Somerset County",
       "Party": "Democrat",
       "ID": 694
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Howard County",
+      "District": "Talbot County",
       "Party": "Democrat",
       "ID": 695
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Kent County",
+      "District": "Washington County",
       "Party": "Democrat",
       "ID": 696
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Queen Anne's County",
+      "District": "Wicomico County",
       "Party": "Democrat",
       "ID": 697
     },
     {
-      "Name": "Democratic Central Committee Male",
+      "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Saint Mary's County",
+      "District": "Legislative District 21",
       "Party": "Democrat",
       "ID": 698
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Somerset County",
-      "Party": "Democrat",
-      "ID": 699
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Talbot County",
-      "Party": "Democrat",
-      "ID": 700
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Washington County",
-      "Party": "Democrat",
-      "ID": 701
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Wicomico County",
-      "Party": "Democrat",
-      "ID": 702
-    },
-    {
-      "Name": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21",
-      "Party": "Democrat",
-      "ID": 703
-    },
-    {
-      "Name": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21",
-      "Party": "Democrat",
-      "ID": 704
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32",
       "Party": "Democrat",
-      "ID": 705
+      "ID": 699
     },
     {
       "Name": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 33",
       "Party": "Democrat",
-      "ID": 706
+      "ID": 700
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County",
       "Party": "Republican",
-      "ID": 707
+      "ID": 701
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Calvert County",
       "Party": "Republican",
-      "ID": 708
+      "ID": 702
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Caroline County",
       "Party": "Republican",
-      "ID": 709
+      "ID": 703
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County",
       "Party": "Republican",
-      "ID": 710
+      "ID": 704
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County",
       "Party": "Republican",
-      "ID": 711
+      "ID": 705
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County",
       "Party": "Republican",
-      "ID": 712
+      "ID": 706
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Dorchester County",
       "Party": "Republican",
-      "ID": 713
+      "ID": 707
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County",
       "Party": "Republican",
-      "ID": 714
+      "ID": 708
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Garrett County",
       "Party": "Republican",
-      "ID": 715
+      "ID": 709
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County",
       "Party": "Republican",
-      "ID": 716
+      "ID": 710
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County",
       "Party": "Republican",
-      "ID": 717
+      "ID": 711
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Kent County",
       "Party": "Republican",
-      "ID": 718
+      "ID": 712
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County",
       "Party": "Republican",
-      "ID": 719
+      "ID": 713
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County",
       "Party": "Republican",
-      "ID": 720
+      "ID": 714
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Somerset County",
       "Party": "Republican",
-      "ID": 721
+      "ID": 715
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County",
       "Party": "Republican",
-      "ID": 722
+      "ID": 716
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County",
       "Party": "Republican",
-      "ID": 723
+      "ID": 717
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County",
       "Party": "Republican",
-      "ID": 724
+      "ID": 718
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Worcester County",
       "Party": "Republican",
-      "ID": 725
+      "ID": 719
     },
     {
       "Name": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County",
       "Party": "Republican",
-      "ID": 726
+      "ID": 720
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 14",
+      "Party": "Republican",
+      "ID": 721
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Republican",
+      "ID": 722
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Republican",
+      "ID": 723
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Republican",
+      "ID": 724
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Republican",
+      "ID": 725
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Republican",
+      "ID": 726
+    },
+    {
+      "Name": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
       "Party": "Republican",
       "ID": 727
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 15",
+      "District": "Legislative District 21",
       "Party": "Republican",
       "ID": 728
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 16",
+      "District": "Legislative District 22",
       "Party": "Republican",
       "ID": 729
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 17",
+      "District": "Legislative District 32",
       "Party": "Republican",
       "ID": 730
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 18",
+      "District": "Legislative District 33",
       "Party": "Republican",
       "ID": 731
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 19",
+      "District": "Legislative District 39",
       "Party": "Republican",
       "ID": 732
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 20",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 1",
       "Party": "Republican",
       "ID": 733
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1",
       "Party": "Republican",
       "ID": 734
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 2",
       "Party": "Republican",
       "ID": 735
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 22",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 2",
       "Party": "Republican",
       "ID": 736
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 32",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 3",
       "Party": "Republican",
       "ID": 737
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 33",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3",
       "Party": "Republican",
       "ID": 738
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 39",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 4",
       "Party": "Republican",
       "ID": 739
     },
     {
       "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 1",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 4",
       "Party": "Republican",
       "ID": 740
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 1",
+      "District": "Councilmanic District 5",
       "Party": "Republican",
       "ID": 741
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 2",
+      "District": "Councilmanic District 6",
       "Party": "Republican",
       "ID": 742
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 2",
+      "District": "Councilmanic District 6",
       "Party": "Republican",
       "ID": 743
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 3",
+      "District": "Councilmanic District 7",
       "Party": "Republican",
       "ID": 744
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 3",
+      "District": "Councilmanic District 7",
       "Party": "Republican",
       "ID": 745
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 4",
-      "Party": "Republican",
-      "ID": 746
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 4",
-      "Party": "Republican",
-      "ID": 747
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 5",
-      "Party": "Republican",
-      "ID": 748
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 6",
-      "Party": "Republican",
-      "ID": 749
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 6",
-      "Party": "Republican",
-      "ID": 750
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 7",
-      "Party": "Republican",
-      "ID": 751
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 7",
-      "Party": "Republican",
-      "ID": 752
-    },
-    {
-      "Name": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 8",
       "Party": "Republican",
-      "ID": 753
+      "ID": 746
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 9",
       "Party": "Republican",
-      "ID": 754
+      "ID": 747
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 10",
       "Party": "Republican",
-      "ID": 755
+      "ID": 748
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 11",
       "Party": "Republican",
-      "ID": 756
+      "ID": 749
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 12",
       "Party": "Republican",
-      "ID": 757
+      "ID": 750
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 13",
       "Party": "Republican",
-      "ID": 758
+      "ID": 751
     },
     {
       "Name": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 14",
       "Party": "Republican",
-      "ID": 759
+      "ID": 752
     },
     {
       "Name": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County",
       "Party": "Democrat",
-      "ID": 760
+      "ID": 753
     },
     {
       "Name": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County",
       "Party": "Democrat",
-      "ID": 761
+      "ID": 754
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 14",
       "Party": "Democrat",
-      "ID": 762
+      "ID": 755
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 15",
       "Party": "Democrat",
-      "ID": 763
+      "ID": 756
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 16",
       "Party": "Democrat",
-      "ID": 764
+      "ID": 757
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17",
       "Party": "Democrat",
-      "ID": 765
+      "ID": 758
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 18",
       "Party": "Democrat",
-      "ID": 766
+      "ID": 759
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 19",
       "Party": "Democrat",
-      "ID": 767
+      "ID": 760
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 20",
       "Party": "Democrat",
-      "ID": 768
+      "ID": 761
     },
     {
       "Name": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39",
+      "Party": "Democrat",
+      "ID": 762
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Party": "Democrat",
+      "ID": 763
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Party": "Democrat",
+      "ID": 764
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Party": "Democrat",
+      "ID": 765
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Party": "Democrat",
+      "ID": 766
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Party": "Democrat",
+      "ID": 767
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Party": "Democrat",
+      "ID": 768
+    },
+    {
+      "Name": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
       "Party": "Democrat",
       "ID": 769
     },
     {
       "Name": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 14",
-      "Party": "Democrat",
-      "ID": 770
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 15",
-      "Party": "Democrat",
-      "ID": 771
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 16",
-      "Party": "Democrat",
-      "ID": 772
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 17",
-      "Party": "Democrat",
-      "ID": 773
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 18",
-      "Party": "Democrat",
-      "ID": 774
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 19",
-      "Party": "Democrat",
-      "ID": 775
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 20",
-      "Party": "Democrat",
-      "ID": 776
-    },
-    {
-      "Name": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39",
       "Party": "Democrat",
-      "ID": 777
+      "ID": 770
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County",
       "Party": "Non Partisan",
-      "ID": 778
+      "ID": 771
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County",
       "Party": "Non Partisan",
-      "ID": 779
+      "ID": 772
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County",
       "Party": "Non Partisan",
-      "ID": 780
+      "ID": 773
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County",
       "Party": "Non Partisan",
-      "ID": 781
+      "ID": 774
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County",
       "Party": "Non Partisan",
-      "ID": 782
+      "ID": 775
     },
     {
       "Name": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County",
       "Party": "Non Partisan",
-      "ID": 783
+      "ID": 776
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Montgomery County",
       "District": "Board of Education District 3",
       "Party": "Non Partisan",
-      "ID": 784
+      "ID": 777
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Queen Anne's County",
       "District": "Commissioner District 2",
       "Party": "Non Partisan",
-      "ID": 785
+      "ID": 778
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Garrett County",
       "District": "Commissioner District 3",
       "Party": "Non Partisan",
-      "ID": 786
+      "ID": 779
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 2",
       "Party": "Non Partisan",
-      "ID": 787
+      "ID": 780
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 3",
       "Party": "Non Partisan",
-      "ID": 788
+      "ID": 781
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 6",
       "Party": "Non Partisan",
-      "ID": 789
+      "ID": 782
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 9",
       "Party": "Non Partisan",
-      "ID": 790
+      "ID": 783
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 1",
       "Party": "Non Partisan",
-      "ID": 791
+      "ID": 784
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 1",
       "Party": "Non Partisan",
-      "ID": 792
+      "ID": 785
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Wicomico County",
       "District": "Councilmanic District 1",
       "Party": "Non Partisan",
-      "ID": 793
+      "ID": 786
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 3",
       "Party": "Non Partisan",
-      "ID": 794
+      "ID": 787
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 4",
       "Party": "Non Partisan",
-      "ID": 795
+      "ID": 788
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 4",
       "Party": "Non Partisan",
-      "ID": 796
+      "ID": 789
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Wicomico County",
       "District": "Councilmanic District 4",
       "Party": "Non Partisan",
-      "ID": 797
+      "ID": 790
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 5",
       "Party": "Non Partisan",
-      "ID": 798
+      "ID": 791
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 7",
       "Party": "Non Partisan",
-      "ID": 799
+      "ID": 792
     },
     {
       "Name": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 7",
       "Party": "Non Partisan",
-      "ID": 800
+      "ID": 793
     }
   ],
   "AllOptions": [
@@ -5613,7 +5564,7 @@
       "District": "Kent County"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Aaron Graham",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -5627,14 +5578,14 @@
       "District": "Legislative District 44B"
     },
     {
-      "ID": 751,
+      "ID": 744,
       "Name": "Aaron Kates",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 774,
+      "ID": 767,
       "Name": "Aaron M. Kaufman",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -5655,14 +5606,14 @@
       "District": "Worcester County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Abel Amdetsyon",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Abena Affum-McAllister",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -5676,7 +5627,7 @@
       "District": "Congressional District 3"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Adam Hiob",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -5690,7 +5641,7 @@
       "District": "Legislative District 37"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Adol T. Owen-Williams, II",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -5725,14 +5676,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "A. Hugh Williams",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 680,
+      "ID": 675,
       "Name": "Airlee Ringgold Johnson",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -5746,16 +5697,16 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 216,
+      "ID": 661,
       "Name": "Aisha Khan",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44B"
     },
     {
-      "ID": 666,
+      "ID": 216,
       "Name": "Aisha Khan",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44B"
     },
@@ -5767,7 +5718,7 @@
       "District": "Howard County"
     },
     {
-      "ID": 701,
+      "ID": 696,
       "Name": "Alan Levin",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -5788,7 +5739,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Al Apatira",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -5844,7 +5795,7 @@
       "District": "Legislative District 44"
     },
     {
-      "ID": 731,
+      "ID": 725,
       "Name": "Alexander Alan Bush",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -5858,7 +5809,7 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 706,
+      "ID": 700,
       "Name": "Alexandra Matiella Novak",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -5872,7 +5823,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Alex J. Garcia",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -5886,7 +5837,7 @@
       "District": "Allegany County"
     },
     {
-      "ID": 747,
+      "ID": 740,
       "Name": "Alfred Mendelsohn",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -5900,7 +5851,7 @@
       "District": "Legislative District 30A"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Alicia Altamirano",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -5914,7 +5865,7 @@
       "District": "Legislative District 19"
     },
     {
-      "ID": 732,
+      "ID": 726,
       "Name": "Alirio E. Martinez, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -5935,7 +5886,7 @@
       "District": "Kent County"
     },
     {
-      "ID": 793,
+      "ID": 786,
       "Name": "Allen C. Brown",
       "Contest": "Board of Education",
       "Jurisdiction": "Wicomico County",
@@ -5984,16 +5935,16 @@
       "District": "Legislative District 22"
     },
     {
-      "ID": 739,
+      "ID": 92,
       "Name": "Al Phillips",
-      "Contest": "Republican Central Committee",
+      "Contest": "State Senator",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39"
     },
     {
-      "ID": 92,
+      "ID": 732,
       "Name": "Al Phillips",
-      "Contest": "State Senator",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39"
     },
@@ -6012,7 +5963,7 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Alvin Stewart",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -6033,7 +5984,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 686,
+      "ID": 681,
       "Name": "Amanda L. Jackson",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -6103,21 +6054,21 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Andrea Mayer",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Andrea M. Beall",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 705,
+      "ID": 699,
       "Name": "Andrea Muriel Jones-Horton",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6180,7 +6131,7 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 701,
+      "ID": 696,
       "Name": "Andrew J. Brown",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -6194,7 +6145,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Andy Aviles",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
@@ -6236,7 +6187,7 @@
       "District": "Legislative District 45"
     },
     {
-      "ID": 742,
+      "ID": 735,
       "Name": "Andy Zipay",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -6257,7 +6208,7 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Angela Ariel McIntosh",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6271,7 +6222,7 @@
       "District": "Legislative District 41"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Angela C. Gibson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6292,6 +6243,13 @@
       "District": "Legislative District 26"
     },
     {
+      "ID": 738,
+      "Name": "Angela Sudano-Marcellino",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3"
+    },
+    {
       "ID": 124,
       "Name": "Angela Sudano-Marcellino",
       "Contest": "House of Delegates",
@@ -6299,21 +6257,14 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 745,
-      "Name": "Angela Sudano-Marcellino",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 3"
-    },
-    {
-      "ID": 660,
+      "ID": 655,
       "Name": "Angelo Salvatrove Lewis",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 40"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Angie Winder",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6334,14 +6285,14 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Anita Pandey",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 673,
+      "ID": 668,
       "Name": "Anita Riley",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -6362,7 +6313,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 797,
+      "ID": 790,
       "Name": "Ann Brittingham Suthowski",
       "Contest": "Board of Education",
       "Jurisdiction": "Wicomico County",
@@ -6376,21 +6327,21 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 738,
+      "ID": 731,
       "Name": "Anne Elizabeth Rutherford",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 33"
     },
     {
-      "ID": 663,
+      "ID": 658,
       "Name": "Anne George",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 42B"
     },
     {
-      "ID": 673,
+      "ID": 668,
       "Name": "Anne Gibson Stoner",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -6404,7 +6355,7 @@
       "District": "Legislative District 22"
     },
     {
-      "ID": 727,
+      "ID": 721,
       "Name": "Anne Koutsoutis",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6425,13 +6376,6 @@
       "District": "Legislative District 14"
     },
     {
-      "ID": 401,
-      "Name": "Annette DeCesaris",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 5"
-    },
-    {
       "ID": 400,
       "Name": "Annette DeCesaris",
       "Contest": "Judge of the Circuit Court",
@@ -6439,7 +6383,14 @@
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 726,
+      "ID": 401,
+      "Name": "Annette DeCesaris",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5"
+    },
+    {
+      "ID": 720,
       "Name": "Ann Guthrie Hingston",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -6453,7 +6404,7 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 764,
+      "ID": 757,
       "Name": "Ann Racuya-Robbins",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -6495,28 +6446,28 @@
       "District": "Charles County"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "Anthony Triplin",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 6"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Antoinette \"Netty\" Rucker",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Antonio Bowens",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Antonio Glover",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6530,14 +6481,14 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 655,
+      "ID": 652,
       "Name": "Antwan C. Brown",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 26"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "April Fleming Miller",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -6558,14 +6509,14 @@
       "District": "Legislative District 16"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Arlene B. Fisher",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 40"
     },
     {
-      "ID": 746,
+      "ID": 739,
       "Name": "Armand F. Girard",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -6579,14 +6530,14 @@
       "District": "Legislative District 30A"
     },
     {
-      "ID": 730,
+      "ID": 724,
       "Name": "Aron K. Schwartz",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
     {
-      "ID": 770,
+      "ID": 763,
       "Name": "Arthur Edmunds",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -6614,7 +6565,7 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 790,
+      "ID": 783,
       "Name": "Arun Puracken",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -6628,7 +6579,7 @@
       "District": "Legislative District 22"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Ashleigh S. Phillips",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -6649,14 +6600,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 796,
+      "ID": 789,
       "Name": "Autrese Thornton",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "Ava Annette Richardson",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -6670,7 +6621,7 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Barbara \"Barb\" Palko",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -6684,7 +6635,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Barbara Osborn Kreamer",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -6698,11 +6649,18 @@
       "District": "Legislative District 34"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Barb Pivec",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
+    },
+    {
+      "ID": 708,
+      "Name": "Barrie S. Ciliberti",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County"
     },
     {
       "ID": 117,
@@ -6712,13 +6670,6 @@
       "District": "Legislative District 4"
     },
     {
-      "ID": 714,
-      "Name": "Barrie S. Ciliberti",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Frederick County"
-    },
-    {
       "ID": 441,
       "Name": "Barry Donadio",
       "Contest": "County Commissioner",
@@ -6726,7 +6677,7 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Barry Donadio",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6740,7 +6691,7 @@
       "District": "Harford County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Bassheva \"Shevy\" Friedman",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6754,14 +6705,14 @@
       "District": "Legislative District 30A"
     },
     {
-      "ID": 387,
+      "ID": 386,
       "Name": "Beau H. Oglesby",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 1"
     },
     {
-      "ID": 386,
+      "ID": 387,
       "Name": "Beau H. Oglesby",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -6775,14 +6726,14 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "Belinda Queen",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 6"
     },
     {
-      "ID": 721,
+      "ID": 715,
       "Name": "Bella Hambrick",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6817,7 +6768,7 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 697,
+      "ID": 692,
       "Name": "Benjamin McNeil",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -6845,7 +6796,7 @@
       "District": "Legislative District 19"
     },
     {
-      "ID": 663,
+      "ID": 658,
       "Name": "Ben Lawrence",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6859,7 +6810,7 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Ben Smith",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -6894,18 +6845,25 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Betty Bland-Thomas",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Beverly June Bigler",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Worcester County"
+    },
+    {
+      "ID": 656,
+      "Name": "Bilal Ali",
+      "Contest": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41"
     },
     {
       "ID": 209,
@@ -6915,21 +6873,14 @@
       "District": "Legislative District 41"
     },
     {
-      "ID": 661,
-      "Name": "Bilal Ali",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 41"
-    },
-    {
-      "ID": 695,
+      "ID": 690,
       "Name": "Bill Adams",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 698,
+      "ID": 693,
       "Name": "Bill Bates",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -6964,18 +6915,18 @@
       "District": "Legislative District 16"
     },
     {
+      "ID": 706,
+      "Name": "Bill Dotson",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County"
+    },
+    {
       "ID": 168,
       "Name": "Bill Dotson",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 28"
-    },
-    {
-      "ID": 712,
-      "Name": "Bill Dotson",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Charles County"
     },
     {
       "ID": 101,
@@ -7006,7 +6957,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Billie Roberts Spann",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7020,7 +6971,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Bill Marker",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7062,7 +7013,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Bill Sylvester",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7083,13 +7034,6 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 714,
-      "Name": "Billy Shreve",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Frederick County"
-    },
-    {
       "ID": 27,
       "Name": "Billy Shreve",
       "Contest": "State Senator",
@@ -7097,16 +7041,23 @@
       "District": "Legislative District 3"
     },
     {
-      "ID": 216,
+      "ID": 708,
+      "Name": "Billy Shreve",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County"
+    },
+    {
+      "ID": 661,
       "Name": "Bishop Barry Chapman",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44B"
     },
     {
-      "ID": 666,
+      "ID": 216,
       "Name": "Bishop Barry Chapman",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44B"
     },
@@ -7132,14 +7083,14 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 758,
+      "ID": 751,
       "Name": "Blaire Freed",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 13"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Bob Amato",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7195,14 +7146,14 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Bob Farrell",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Bob Farrell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7216,7 +7167,7 @@
       "District": "Legislative District 9B"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Bob Ford",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -7230,7 +7181,7 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Bob Glascock",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -7251,7 +7202,7 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Bob Lord",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -7300,16 +7251,16 @@
       "District": "Frederick County"
     },
     {
-      "ID": 578,
+      "ID": 680,
       "Name": "Bonnie Wood",
-      "Contest": "Judge of the Orphans' Court",
+      "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 685,
+      "ID": 578,
       "Name": "Bonnie Wood",
-      "Contest": "Democratic Central Committee Female",
+      "Contest": "Judge of the Orphans' Court",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
@@ -7321,21 +7272,14 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 642,
-      "Name": "Brad Kroner",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 7"
-    },
-    {
-      "ID": 748,
+      "ID": 741,
       "Name": "Bradley Lang",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 728,
+      "ID": 722,
       "Name": "Bradley St. Rohrs",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7349,7 +7293,7 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Brad W. Young",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -7363,14 +7307,14 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Brandon Matthew Holland",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Brandon Orman Rippeon",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -7384,7 +7328,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Braxton C. Street",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7398,7 +7342,7 @@
       "District": "Legislative District 21"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Brenda Hatcher-Savoy",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7412,7 +7356,7 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 742,
+      "ID": 735,
       "Name": "Brendon Tamont Joyner-El",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -7426,7 +7370,7 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Brett Lysinger",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7482,7 +7426,7 @@
       "District": "Legislative District 31B"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "Brian Clothier",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -7510,7 +7454,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 773,
+      "ID": 766,
       "Name": "Brian Gene Walton",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -7531,13 +7475,6 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 752,
-      "Name": "Brian J. Noon",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 7"
-    },
-    {
       "ID": 590,
       "Name": "Brian J. Noon",
       "Contest": "Sheriff",
@@ -7545,28 +7482,28 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 687,
+      "ID": 745,
+      "Name": "Brian J. Noon",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 7"
+    },
+    {
+      "ID": 682,
       "Name": "Brian K. Grim",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 648,
+      "ID": 646,
       "Name": "Brian K. McDaniel",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 21"
     },
     {
-      "ID": 649,
-      "Name": "Brian K. McDaniel",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 666,
+      "ID": 661,
       "Name": "Brian L. Huffman",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7587,7 +7524,7 @@
       "District": "Legislative District 29B"
     },
     {
-      "ID": 772,
+      "ID": 765,
       "Name": "Brian Michael Doherty",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -7601,14 +7538,14 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Brian Paul Tana",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 715,
+      "ID": 709,
       "Name": "Brian Schlossnagle",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7671,7 +7608,7 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Bruce Leith",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7685,7 +7622,7 @@
       "District": "Kent County"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Bryan M. Barthelme, II",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7699,14 +7636,14 @@
       "District": "Legislative District 31"
     },
     {
-      "ID": 745,
+      "ID": 738,
       "Name": "B. Scott Patrick",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Buck Taylor",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7741,7 +7678,7 @@
       "District": "Congressional District 2"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "Caleb A. Camara",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -7755,14 +7692,14 @@
       "District": "Legislative District 23B"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Cal Steuart",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Calvert County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Calvin Allen Young, III",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7790,35 +7727,35 @@
       "District": "Orphans' Court District 2"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Camden Raynor",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 773,
+      "ID": 766,
       "Name": "Cameron Rhode",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Camille Baca O'Donnell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 791,
+      "ID": 784,
       "Name": "Candace C.W. Antwine",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Candace Dodson-Reed",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -7832,7 +7769,7 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 739,
+      "ID": 732,
       "Name": "Candice Clough",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -7853,13 +7790,6 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 394,
-      "Name": "Carey Deeley",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 3"
-    },
-    {
       "ID": 395,
       "Name": "Carey Deeley",
       "Contest": "Judge of the Circuit Court",
@@ -7867,7 +7797,14 @@
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 686,
+      "ID": 394,
+      "Name": "Carey Deeley",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3"
+    },
+    {
+      "ID": 681,
       "Name": "Carissa Antonis",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -7881,14 +7818,14 @@
       "District": "Legislative District 38B"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Carl C. Thomas, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Carleen Pena",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -7944,7 +7881,7 @@
       "District": "Legislative District 19"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Carmen B. Jackson",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -7958,7 +7895,7 @@
       "District": "Legislative District 30B"
     },
     {
-      "ID": 682,
+      "ID": 677,
       "Name": "Caroline Miller King",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -7972,14 +7909,14 @@
       "District": "Legislative District 3A"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Carol MacCubbin",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Carol M. Kiple",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8000,14 +7937,14 @@
       "District": "Cecil County"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "Carolyn Maria Boston",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 6"
     },
     {
-      "ID": 785,
+      "ID": 778,
       "Name": "Carrie Lee O'Connor",
       "Contest": "Board of Education",
       "Jurisdiction": "Queen Anne's County",
@@ -8021,28 +7958,28 @@
       "District": "Washington County"
     },
     {
-      "ID": 788,
+      "ID": 781,
       "Name": "Catherine Bennett Nwosu",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 3"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Catherine Grasso",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Calvert County"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Cathey Allison",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Cathey Allison",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8077,28 +8014,28 @@
       "District": "Councilmanic District D"
     },
     {
-      "ID": 748,
+      "ID": 741,
       "Name": "Chandra P. Sharma Belbase",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Chanel A. Branch",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Chao Wu",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Charlee Childs",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8112,7 +8049,7 @@
       "District": "Cecil County"
     },
     {
-      "ID": 759,
+      "ID": 752,
       "Name": "Charles A. Long",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -8154,7 +8091,7 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Charles \"Chuck\" McClam",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -8168,6 +8105,13 @@
       "District": "Commissioner District 2"
     },
     {
+      "ID": 684,
+      "Name": "Charles E. Harrison",
+      "Contest": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County"
+    },
+    {
       "ID": 558,
       "Name": "Charles E. Harrison",
       "Contest": "Judge of the Orphans' Court",
@@ -8175,14 +8119,7 @@
       "District": "Carroll County"
     },
     {
-      "ID": 689,
-      "Name": "Charles E. Harrison",
-      "Contest": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Carroll County"
-    },
-    {
-      "ID": 666,
+      "ID": 661,
       "Name": "Charles E. Sydnor, III",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8203,14 +8140,14 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 412,
+      "ID": 413,
       "Name": "Charles H. Dorsey",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 8"
     },
     {
-      "ID": 413,
+      "ID": 412,
       "Name": "Charles H. Dorsey",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -8280,7 +8217,7 @@
       "District": "Legislative District 19"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Chaz Packan",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -8336,14 +8273,14 @@
       "District": "Legislative District 23"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Chezia Cager",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 769,
+      "ID": 762,
       "Name": "Chibuzor M. Nwosu",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -8371,7 +8308,7 @@
       "District": "Commissioner District 5"
     },
     {
-      "ID": 666,
+      "ID": 661,
       "Name": "Chris Burk",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8399,7 +8336,7 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Chris Kirby",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8413,7 +8350,7 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Chris Oxenham",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8441,7 +8378,7 @@
       "District": "Legislative District 30"
     },
     {
-      "ID": 730,
+      "ID": 724,
       "Name": "Chris Thoms",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8476,11 +8413,18 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Christina M. Trotta",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
+    },
+    {
+      "ID": 748,
+      "Name": "Christine Digman",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 10"
     },
     {
       "ID": 102,
@@ -8490,21 +8434,14 @@
       "District": "Legislative District 46"
     },
     {
-      "ID": 755,
-      "Name": "Christine Digman",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 10"
-    },
-    {
-      "ID": 716,
+      "ID": 710,
       "Name": "Christopher Anthoney Sigley",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Christopher C. Boardman",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -8518,14 +8455,14 @@
       "District": "Harford County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Christopher Delgado Bradbury",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 729,
+      "ID": 723,
       "Name": "Christopher Dexter Haas",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8539,7 +8476,7 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Christopher Ervin",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8553,42 +8490,42 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 759,
+      "ID": 752,
       "Name": "Christopher Hughes Carper",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 14"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Christopher Izzo",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 687,
+      "ID": 682,
       "Name": "Christopher John Logsdon",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Christopher Michael Hilfiger",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Christopher R. Weaver",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 775,
+      "ID": 768,
       "Name": "Christopher Steven Jennison",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -8602,7 +8539,7 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Christopher Tomlinson",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8644,7 +8581,7 @@
       "District": "Talbot County"
     },
     {
-      "ID": 706,
+      "ID": 700,
       "Name": "Chuck Cook",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8665,28 +8602,28 @@
       "District": "Frederick County"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Cindy Emmerich",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Cindy Rose",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Cindy Skilton",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "C. Karen Altieri",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8700,7 +8637,7 @@
       "District": "Legislative District 12"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Clarevonte \"Clay\" Williams",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -8721,28 +8658,21 @@
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 685,
+      "ID": 680,
       "Name": "Claudia Martin",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Clayton Robert Boone",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 648,
-      "Name": "Cliff Green",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 649,
+      "ID": 646,
       "Name": "Cliff Green",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8756,7 +8686,7 @@
       "District": "Legislative District 39"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Cody Hance",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8777,21 +8707,21 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 698,
+      "ID": 693,
       "Name": "Collin Jay Foster",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Connie Onspaugh",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Connie Sheer",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -8812,7 +8742,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Cordell Hunter, Sr.",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -8840,7 +8770,7 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 673,
+      "ID": 668,
       "Name": "Corynne B. Courpas",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -8938,21 +8868,21 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Crystal Jackson Parker",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 40"
     },
     {
-      "ID": 686,
+      "ID": 681,
       "Name": "Crystal Jones",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 196,
+      "ID": 197,
       "Name": "Crystal Woodward",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
@@ -8966,28 +8896,7 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 197,
-      "Name": "Crystal Woodward",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
-      "ID": 197,
-      "Name": "Crystal Woodward",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
       "ID": 196,
-      "Name": "Crystal Woodward",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
-      "ID": 198,
       "Name": "Crystal Woodward",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
@@ -9015,21 +8924,21 @@
       "District": "Councilmanic District F"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Cynthia G. Trout",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Cynthia Hendricks Jones",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Cynthia Houser",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9050,7 +8959,7 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 701,
+      "ID": 696,
       "Name": "Dale F. Ruby",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -9078,13 +8987,6 @@
       "District": "Legislative District 18"
     },
     {
-      "ID": 412,
-      "Name": "Dana Michele Middleton",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 8"
-    },
-    {
       "ID": 413,
       "Name": "Dana Michele Middleton",
       "Contest": "Judge of the Circuit Court",
@@ -9092,7 +8994,14 @@
       "District": "Judicial Circuit 8"
     },
     {
-      "ID": 798,
+      "ID": 412,
+      "Name": "Dana Michele Middleton",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 8"
+    },
+    {
+      "ID": 791,
       "Name": "Dana Schallheim",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -9113,7 +9022,7 @@
       "District": "Legislative District 11"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Dana Vickers Shelley",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9127,14 +9036,14 @@
       "District": "Legislative District 4"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Dan Cox",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 728,
+      "ID": 722,
       "Name": "Dan Cuda",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9148,14 +9057,7 @@
       "District": "Garrett County"
     },
     {
-      "ID": 648,
-      "Name": "Daniel Alpert",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 649,
+      "ID": 646,
       "Name": "Daniel Alpert",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9169,7 +9071,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Daniel J. Keller",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9225,14 +9127,14 @@
       "District": "Frederick County"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Danny Mackey",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Danny M. Blount",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9267,14 +9169,14 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 669,
+      "ID": 664,
       "Name": "Dante Bishop",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 47A"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Danyell P. Smith",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9302,7 +9204,7 @@
       "District": "Legislative District 12"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Darius Craig",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9316,7 +9218,7 @@
       "District": "Charles County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Darrell Anderson",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
@@ -9351,14 +9253,14 @@
       "District": "Legislative District 25"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Darryl Perry",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Darryl Strange",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9386,7 +9288,7 @@
       "District": "Allegany County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Dave Grabowski",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -9407,14 +9309,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Dave Kunes",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Dave Myers",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9435,7 +9337,7 @@
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "David A. Bohn",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -9463,7 +9365,7 @@
       "District": "Allegany County"
     },
     {
-      "ID": 742,
+      "ID": 735,
       "Name": "David Anthony Wiggins",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -9477,14 +9379,14 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "David A. Wiley",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Calvert County"
     },
     {
-      "ID": 688,
+      "ID": 683,
       "Name": "David B. Johnson",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -9498,7 +9400,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 721,
+      "ID": 715,
       "Name": "David B. Lloyd",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9526,7 +9428,7 @@
       "District": "Legislative District 5"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "David E. Shelton",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -9540,21 +9442,21 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "David Hancock",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 650,
+      "ID": 647,
       "Name": "David Hiles",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 22"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "David J. Perez",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9568,28 +9470,28 @@
       "District": "Talbot County"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "David J. Woodruff",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "David L. Brauning, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "David L. Goslee, Sr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "David Louis Snyder",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9617,28 +9519,28 @@
       "District": "Calvert County"
     },
     {
-      "ID": 797,
+      "ID": 790,
       "Name": "David Plotts",
       "Contest": "Board of Education",
       "Jurisdiction": "Wicomico County",
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 737,
+      "ID": 730,
       "Name": "David P. Starr",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32"
     },
     {
-      "ID": 791,
+      "ID": 784,
       "Name": "David P. Starr",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "David Reel",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9687,14 +9589,14 @@
       "District": "Harford County"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "David Wharton",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Kent County"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "David Willenborg",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -9708,14 +9610,14 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 407,
+      "ID": 406,
       "Name": "David W. Lease",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 6"
     },
     {
-      "ID": 406,
+      "ID": 407,
       "Name": "David W. Lease",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -9806,14 +9708,14 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 792,
+      "ID": 785,
       "Name": "Deborah Arnetta Cason",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Deborah Carter",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -9827,7 +9729,7 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 681,
+      "ID": 676,
       "Name": "Deborah Krueger",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -9841,14 +9743,14 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 730,
+      "ID": 724,
       "Name": "Deborah Lambert",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Deborah Reynolds",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -9862,7 +9764,7 @@
       "District": "Legislative District 28"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Debra Frank",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -9897,7 +9799,7 @@
       "District": "Councilmanic District 6"
     },
     {
-      "ID": 767,
+      "ID": 760,
       "Name": "Deirdre Gallagher",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -9911,11 +9813,18 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 728,
+      "ID": 722,
       "Name": "Del Lamiman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 15"
+    },
+    {
+      "ID": 643,
+      "Name": "Delores G. Kelley",
+      "Contest": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10"
     },
     {
       "ID": 41,
@@ -9925,42 +9834,28 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 644,
-      "Name": "Delores G. Kelley",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 10"
-    },
-    {
-      "ID": 668,
+      "ID": 663,
       "Name": "Denise Bartenfelder Whitman",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 648,
+      "ID": 646,
       "Name": "Denise C. Mitchell",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 21"
     },
     {
-      "ID": 649,
-      "Name": "Denise C. Mitchell",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 667,
+      "ID": 662,
       "Name": "Denise C. Richards",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Denise E. Perry",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -9988,14 +9883,14 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 753,
+      "ID": 746,
       "Name": "Dennis Betzel",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 8"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Dennis Brent Melby",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -10009,13 +9904,6 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 388,
-      "Name": "Dennis Farina",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 2"
-    },
-    {
       "ID": 389,
       "Name": "Dennis Farina",
       "Contest": "Judge of the Circuit Court",
@@ -10023,7 +9911,14 @@
       "District": "Judicial Circuit 2"
     },
     {
-      "ID": 655,
+      "ID": 388,
+      "Name": "Dennis Farina",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2"
+    },
+    {
+      "ID": 652,
       "Name": "Dennis H. Rowe",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10079,7 +9974,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 742,
+      "ID": 735,
       "Name": "Derod G. Broady",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -10107,7 +10002,7 @@
       "District": "Councilmanic District 6"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Derrick Lockhart",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -10128,28 +10023,28 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Destinee Parker",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 43"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Dhaval Shah",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 671,
+      "ID": 666,
       "Name": "Diana Allee Beverlin",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 682,
+      "ID": 677,
       "Name": "Diana D. Donahue",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -10170,13 +10065,6 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 396,
-      "Name": "Diane Adkins-Tobin",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 3"
-    },
-    {
       "ID": 397,
       "Name": "Diane Adkins-Tobin",
       "Contest": "Judge of the Circuit Court",
@@ -10184,7 +10072,14 @@
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 711,
+      "ID": 396,
+      "Name": "Diane Adkins-Tobin",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3"
+    },
+    {
+      "ID": 705,
       "Name": "Diane Carabetta",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10212,18 +10107,18 @@
       "District": "Legislative District 26"
     },
     {
+      "ID": 692,
+      "Name": "Dino Romano LaMana",
+      "Contest": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County"
+    },
+    {
       "ID": 424,
       "Name": "Dino Romano LaMana",
       "Contest": "County Commissioner",
       "Jurisdiction": "Queen Anne's County",
       "District": "Commissioner District 1"
-    },
-    {
-      "ID": 697,
-      "Name": "Dino Romano LaMana",
-      "Contest": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Queen Anne's County"
     },
     {
       "ID": 343,
@@ -10240,7 +10135,7 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 731,
+      "ID": 725,
       "Name": "Dolores Reyes",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10261,28 +10156,28 @@
       "District": "Talbot County"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Dona Donadio",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Dona Goeller",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Donald Garmer",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 732,
+      "ID": 726,
       "Name": "Donald Irvine",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10303,7 +10198,7 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 790,
+      "ID": 783,
       "Name": "Don D. Massey",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -10317,18 +10212,11 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 689,
+      "ID": 684,
       "Name": "Don H. West",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
-    },
-    {
-      "ID": 408,
-      "Name": "Donine Marie Carrington",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 7"
     },
     {
       "ID": 409,
@@ -10338,16 +10226,23 @@
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 635,
-      "Name": "Donjuan \"DJ\" Williams",
-      "Contest": "Democratic Central Committee At Large",
+      "ID": 408,
+      "Name": "Donine Marie Carrington",
+      "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 24"
+      "District": "Judicial Circuit 7"
     },
     {
       "ID": 159,
       "Name": "Donjuan \"DJ\" Williams",
       "Contest": "House of Delegates",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24"
+    },
+    {
+      "ID": 635,
+      "Name": "Donjuan \"DJ\" Williams",
+      "Contest": "Democratic Central Committee At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 24"
     },
@@ -10387,14 +10282,14 @@
       "District": "Washington County"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Donna L. Kahoe",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 795,
+      "ID": 788,
       "Name": "Donna L. Rober",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -10415,14 +10310,14 @@
       "District": "Washington County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Donoven Brooks",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 705,
+      "ID": 699,
       "Name": "Don Rau",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10443,7 +10338,7 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Dottery Butler-Washington",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -10457,7 +10352,7 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Doug Howard",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -10478,7 +10373,7 @@
       "District": "Legislative District 23"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Douglas L. Johnston",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10513,7 +10408,7 @@
       "District": "Legislative District 30A"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Doug Sayers",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -10534,7 +10429,7 @@
       "District": "Councilmanic District 6"
     },
     {
-      "ID": 756,
+      "ID": 749,
       "Name": "Duane Shelton",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -10548,14 +10443,14 @@
       "District": "Calvert County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Dwayne Benbow",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Dwight Patel",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -10597,7 +10492,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Earle Hatton",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -10632,7 +10527,7 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Edison Joseph Hatter",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -10660,13 +10555,6 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 642,
-      "Name": "Ed Livingston",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 7"
-    },
-    {
       "ID": 375,
       "Name": "Ed Rothstein",
       "Contest": "County Commissioner",
@@ -10674,18 +10562,18 @@
       "District": "Commissioner District 5"
     },
     {
-      "ID": 725,
-      "Name": "Ed Tinus",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Worcester County"
-    },
-    {
       "ID": 205,
       "Name": "Ed Tinus",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 38C"
+    },
+    {
+      "ID": 719,
+      "Name": "Ed Tinus",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County"
     },
     {
       "ID": 13,
@@ -10702,7 +10590,7 @@
       "District": "Allegany County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Edward Fischman",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
@@ -10723,13 +10611,6 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 391,
-      "Name": "Edwin B. Fockler, IV",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 2"
-    },
-    {
       "ID": 390,
       "Name": "Edwin B. Fockler, IV",
       "Contest": "Judge of the Circuit Court",
@@ -10737,14 +10618,21 @@
       "District": "Judicial Circuit 2"
     },
     {
-      "ID": 685,
+      "ID": 391,
+      "Name": "Edwin B. Fockler, IV",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2"
+    },
+    {
+      "ID": 680,
       "Name": "Edythe M. Rickard",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 681,
+      "ID": 676,
       "Name": "Elaine F. McNeil",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -10786,7 +10674,7 @@
       "District": "Kent County"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Elizabeth \"Liz\" Brown",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -10807,14 +10695,14 @@
       "District": "Washington County"
     },
     {
-      "ID": 643,
+      "ID": 642,
       "Name": "Elizabeth W. Brown",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 8"
     },
     {
-      "ID": 705,
+      "ID": 699,
       "Name": "Elizabeth Ysla Leight",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10828,7 +10716,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Ellie Mitchell",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10849,18 +10737,25 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 705,
+      "ID": 699,
       "Name": "Emil Yaw Donkor",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32"
     },
     {
-      "ID": 643,
+      "ID": 642,
       "Name": "Emily Lynn Cooke",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 8"
+    },
+    {
+      "ID": 668,
+      "Name": "Emily Shank",
+      "Contest": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County"
     },
     {
       "ID": 120,
@@ -10870,13 +10765,6 @@
       "District": "Legislative District 5"
     },
     {
-      "ID": 673,
-      "Name": "Emily Shank",
-      "Contest": "Democratic Central Committee Female",
-      "Jurisdiction": "State of Maryland",
-      "District": "Carroll County"
-    },
-    {
       "ID": 147,
       "Name": "Emily Shetty",
       "Contest": "House of Delegates",
@@ -10884,7 +10772,7 @@
       "District": "Legislative District 18"
     },
     {
-      "ID": 650,
+      "ID": 647,
       "Name": "Emmett V. Jordan",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10898,7 +10786,7 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Eric Booker",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10912,7 +10800,7 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 800,
+      "ID": 793,
       "Name": "Eric C. Washington",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -10926,14 +10814,14 @@
       "District": "Legislative District 12"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Erich Bean",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Eric Hiltpold",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -10954,21 +10842,14 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 703,
+      "ID": 698,
       "Name": "Eric Stanton Masten",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 21"
     },
     {
-      "ID": 704,
-      "Name": "Eric Stanton Masten",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 665,
+      "ID": 660,
       "Name": "Eric Stephenson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11003,7 +10884,7 @@
       "District": "Councilmanic District 6"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "Erik T. Gulbrandsen",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -11017,21 +10898,21 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 690,
+      "ID": 685,
       "Name": "Ernest Gottfred Olsen",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 654,
+      "ID": 651,
       "Name": "Ernest H. Canlas",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 25"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Erwin David Rose",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
@@ -11045,21 +10926,21 @@
       "District": "Legislative District 17"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "E. Scott Hollenbeck",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Ethel Brown-Hill",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Eugene Ashley Magee",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11073,7 +10954,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 748,
+      "ID": 741,
       "Name": "Eugene S. Craig, III",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -11115,7 +10996,7 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Fallon E. Patton",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11129,14 +11010,14 @@
       "District": "Legislative District 20"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Faye Ellen Snowden",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 653,
+      "ID": 650,
       "Name": "Faye Martin Howell",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11157,14 +11038,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Francesca Rendell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Dorchester County"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Frances Goeller",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11199,7 +11080,7 @@
       "District": "Legislative District 37A"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Frank Elgersma",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11213,16 +11094,16 @@
       "District": "Washington County"
     },
     {
-      "ID": 689,
+      "ID": 558,
       "Name": "Frank Henry Rammes",
-      "Contest": "Democratic Central Committee Male",
+      "Contest": "Judge of the Orphans' Court",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 558,
+      "ID": 684,
       "Name": "Frank Henry Rammes",
-      "Contest": "Judge of the Orphans' Court",
+      "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
@@ -11234,7 +11115,7 @@
       "District": "Charles County"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Franklin Blatt",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11248,7 +11129,7 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Frank Mirabile",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11262,32 +11143,25 @@
       "District": "Commissioner District 5"
     },
     {
-      "ID": 697,
+      "ID": 692,
       "Name": "Frank W. Alduino",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 732,
+      "ID": 726,
       "Name": "Frederick G. Seelman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 19"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Frederick H. Strickland",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 10"
-    },
-    {
-      "ID": 715,
-      "Name": "Fred Fox",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Garrett County"
     },
     {
       "ID": 439,
@@ -11297,7 +11171,14 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 786,
+      "ID": 709,
+      "Name": "Fred Fox",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County"
+    },
+    {
+      "ID": 779,
       "Name": "Fred Gregg",
       "Contest": "Board of Education",
       "Jurisdiction": "Garrett County",
@@ -11346,28 +11227,28 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Gabriela Zabel",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Gabriel M. Moreno",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Gabriel Sorrel",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Gabriel Stuart-Sikowitz",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11381,14 +11262,14 @@
       "District": "Legislative District 9"
     },
     {
-      "ID": 729,
+      "ID": 723,
       "Name": "Gail Weiss",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 16"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Gains Hawkins",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -11402,7 +11283,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 709,
+      "ID": 703,
       "Name": "Garrett Shull",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11423,14 +11304,14 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 693,
+      "ID": 688,
       "Name": "Gary A. Wakefield",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Garrett County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Gary Clark",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11451,42 +11332,42 @@
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 756,
+      "ID": 749,
       "Name": "Gary M. Collins",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 11"
     },
     {
-      "ID": 796,
+      "ID": 789,
       "Name": "Gaston A. Horne",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Gene Legg",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Gene Stanton",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 700,
+      "ID": 695,
       "Name": "Gene W. Counihan",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County"
     },
     {
-      "ID": 709,
+      "ID": 703,
       "Name": "George Bacorn",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11500,7 +11381,7 @@
       "District": "Legislative District 1"
     },
     {
-      "ID": 718,
+      "ID": 712,
       "Name": "George C. Jones",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11570,7 +11451,7 @@
       "District": "Congressional District 4"
     },
     {
-      "ID": 776,
+      "ID": 769,
       "Name": "George Neighbors",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -11598,7 +11479,7 @@
       "District": "Orphans' Court District 1"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "George \"Tip Top Tables\" Williams",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11612,7 +11493,7 @@
       "District": "Worcester County"
     },
     {
-      "ID": 666,
+      "ID": 661,
       "Name": "George White",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11661,21 +11542,21 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Ginger L. Bigelow",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 685,
+      "ID": 680,
       "Name": "Ginger L. Noble",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Gladys Charlene Marcum",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11696,7 +11577,7 @@
       "District": "Legislative District 34A"
     },
     {
-      "ID": 746,
+      "ID": 739,
       "Name": "Glenn E. Bushel",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -11710,7 +11591,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 657,
+      "ID": 653,
       "Name": "Gloria McClam-Magruder",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11724,13 +11605,6 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 656,
-      "Name": "Gloria McClam-Magruder",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27A"
-    },
-    {
       "ID": 123,
       "Name": "Gordon Koerner",
       "Contest": "House of Delegates",
@@ -11738,7 +11612,7 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Gordon Koerner",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -11759,7 +11633,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Grant Helvey",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11773,7 +11647,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Greg Demarco",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11787,28 +11661,28 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 743,
+      "ID": 736,
       "Name": "Gregory Certeza",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 739,
+      "ID": 732,
       "Name": "Gregory Decker",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Gregory Herman Waller, Jr.",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 689,
+      "ID": 684,
       "Name": "Gregory Hutsell",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -11829,7 +11703,7 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 771,
+      "ID": 764,
       "Name": "Greg Wims",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -11850,7 +11724,7 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Gus Alzona",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -11871,14 +11745,14 @@
       "District": "Calvert County"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Hailey McDonald",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 665,
+      "ID": 660,
       "Name": "Haki Shakur Ammi",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11906,18 +11780,11 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 775,
+      "ID": 768,
       "Name": "Harold N. Diamond",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 19"
-    },
-    {
-      "ID": 393,
-      "Name": "Harris Murphy",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 2"
     },
     {
       "ID": 392,
@@ -11927,6 +11794,20 @@
       "District": "Judicial Circuit 2"
     },
     {
+      "ID": 393,
+      "Name": "Harris Murphy",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2"
+    },
+    {
+      "ID": 642,
+      "Name": "Harry Bhandari",
+      "Contest": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8"
+    },
+    {
       "ID": 125,
       "Name": "Harry Bhandari",
       "Contest": "House of Delegates",
@@ -11934,14 +11815,7 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 643,
-      "Name": "Harry Bhandari",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 8"
-    },
-    {
-      "ID": 730,
+      "ID": 724,
       "Name": "Harry Burnett",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -11969,7 +11843,7 @@
       "District": "Washington County"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Harry Wimbrow",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12018,7 +11892,7 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 682,
+      "ID": 677,
       "Name": "Heather Marin Earhart",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -12060,13 +11934,6 @@
       "District": "Calvert County"
     },
     {
-      "ID": 712,
-      "Name": "Henry Thompson",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Charles County"
-    },
-    {
       "ID": 241,
       "Name": "Henry Thompson",
       "Contest": "County Commissioner President",
@@ -12074,14 +11941,21 @@
       "District": "Charles County"
     },
     {
-      "ID": 690,
+      "ID": 706,
+      "Name": "Henry Thompson",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County"
+    },
+    {
+      "ID": 685,
       "Name": "Herbert Welch",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Herbie Smith",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12123,7 +11997,7 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 772,
+      "ID": 765,
       "Name": "Hrant Jamgochian",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12137,7 +12011,7 @@
       "District": "Congressional District 2"
     },
     {
-      "ID": 737,
+      "ID": 730,
       "Name": "Hubert Owens, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12158,21 +12032,21 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 652,
+      "ID": 649,
       "Name": "Ingrid S. Harrison",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 23B"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Ira Kolman",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 788,
+      "ID": 781,
       "Name": "Irene Holtzman",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -12186,7 +12060,7 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Ivory P. Smith, Sr.",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12200,7 +12074,7 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Jacinta Bottoms-Spencer",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12214,21 +12088,21 @@
       "District": "Legislative District 29"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Jackie Addison",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 666,
+      "ID": 661,
       "Name": "Jackie Graves",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44B"
     },
     {
-      "ID": 663,
+      "ID": 658,
       "Name": "Jack R. Sturgill, Jr.",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12242,7 +12116,7 @@
       "District": "Garrett County"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Jackson Leith",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12256,21 +12130,14 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 659,
+      "ID": 654,
       "Name": "Jacqueline Steele-McCall",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 27B"
     },
     {
-      "ID": 658,
-      "Name": "Jacqueline Steele-McCall",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27B"
-    },
-    {
-      "ID": 758,
+      "ID": 751,
       "Name": "Jacquelyn Fisher",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -12291,7 +12158,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Jake Burdett",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12326,13 +12193,6 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 407,
-      "Name": "James A. Bonifant",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 6"
-    },
-    {
       "ID": 406,
       "Name": "James A. Bonifant",
       "Contest": "Judge of the Circuit Court",
@@ -12340,7 +12200,14 @@
       "District": "Judicial Circuit 6"
     },
     {
-      "ID": 712,
+      "ID": 407,
+      "Name": "James A. Bonifant",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6"
+    },
+    {
+      "ID": 706,
       "Name": "James Ashburn",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12375,7 +12242,7 @@
       "District": "Legislative District 21"
     },
     {
-      "ID": 718,
+      "ID": 712,
       "Name": "James Gillman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12410,14 +12277,14 @@
       "District": "Legislative District 1A"
     },
     {
-      "ID": 738,
+      "ID": 731,
       "Name": "James P. Appel",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 33"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "James Reece Peak, III",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12431,14 +12298,7 @@
       "District": "Harford County"
     },
     {
-      "ID": 735,
-      "Name": "James Rim",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 734,
+      "ID": 728,
       "Name": "James Rim",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12452,7 +12312,7 @@
       "District": "Legislative District 34B"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "James Wahl",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12487,14 +12347,14 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 733,
+      "ID": 727,
       "Name": "Jamie Greedan",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 20"
     },
     {
-      "ID": 674,
+      "ID": 669,
       "Name": "Jamie Marshall",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -12522,7 +12382,7 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 682,
+      "ID": 677,
       "Name": "Jane Loughran",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -12543,7 +12403,7 @@
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Jan Eveland",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12557,7 +12417,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 672,
+      "ID": 667,
       "Name": "Janice G. Davison",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -12578,14 +12438,14 @@
       "District": "Legislative District 34B"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Jan Oliver",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Jared Schablein",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12613,14 +12473,14 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Jasmine A. Collins",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Jasmyne Birch",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12641,13 +12501,6 @@
       "District": "Legislative District 1B"
     },
     {
-      "ID": 716,
-      "Name": "Jason C. Gallion",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Harford County"
-    },
-    {
       "ID": 84,
       "Name": "Jason C. Gallion",
       "Contest": "State Senator",
@@ -12655,7 +12508,14 @@
       "District": "Legislative District 35"
     },
     {
-      "ID": 779,
+      "ID": 710,
+      "Name": "Jason C. Gallion",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County"
+    },
+    {
+      "ID": 772,
       "Name": "Jason Helton",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -12676,7 +12536,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 662,
+      "ID": 657,
       "Name": "Jason Sean Garber",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12704,7 +12564,7 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Jay B. Smathers",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12718,16 +12578,16 @@
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 644,
+      "ID": 132,
       "Name": "Jay Jalisi",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 10"
     },
     {
-      "ID": 132,
+      "ID": 643,
       "Name": "Jay Jalisi",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 10"
     },
@@ -12739,7 +12599,7 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Jay Mason",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -12753,7 +12613,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 748,
+      "ID": 741,
       "Name": "Jay Payne",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -12767,7 +12627,7 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 766,
+      "ID": 759,
       "Name": "Jazmin Moral",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -12802,21 +12662,21 @@
       "District": "Legislative District 34A"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "J. D. Wilkins",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 731,
+      "ID": 725,
       "Name": "Jean Alexandra Tuttle",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 18"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Jean Elaine Beulah",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12865,7 +12725,7 @@
       "District": "Legislative District 34B"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Jeffery McBride",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12879,14 +12739,14 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 693,
+      "ID": 688,
       "Name": "Jeff Hovis",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Garrett County"
     },
     {
-      "ID": 690,
+      "ID": 685,
       "Name": "Jeff Kase",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -12907,7 +12767,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 732,
+      "ID": 726,
       "Name": "Jeffrey Brown",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -12942,21 +12802,21 @@
       "District": "Legislative District 32"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Jen Mallo",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 413,
+      "ID": 412,
       "Name": "Jennifer Bridget Schiffer",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 8"
     },
     {
-      "ID": 412,
+      "ID": 413,
       "Name": "Jennifer Bridget Schiffer",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -12970,21 +12830,21 @@
       "District": "Legislative District 3"
     },
     {
-      "ID": 765,
+      "ID": 758,
       "Name": "Jennifer Guzman Hosey",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Jennifer Hayden Boyd",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Jennifer Jones",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -13005,14 +12865,14 @@
       "District": "Legislative District 3"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Jennifer S. Abell",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Jenny Park",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13026,7 +12886,7 @@
       "District": "Legislative District 13"
     },
     {
-      "ID": 701,
+      "ID": 696,
       "Name": "Jereme Weston Leazier",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -13040,21 +12900,21 @@
       "District": "Legislative District 46"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Jeremy Darius Abbott",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Jeremy Eldridge",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Jericka A. Robinson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13068,7 +12928,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Jerry DeWolf",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13131,11 +12991,18 @@
       "District": "Congressional District 1"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Jesse Fields",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
+    },
+    {
+      "ID": 708,
+      "Name": "Jesse T. Pippy",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County"
     },
     {
       "ID": 117,
@@ -13145,14 +13012,7 @@
       "District": "Legislative District 4"
     },
     {
-      "ID": 714,
-      "Name": "Jesse T. Pippy",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Frederick County"
-    },
-    {
-      "ID": 716,
+      "ID": 710,
       "Name": "Jessica Blake",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13222,14 +13082,14 @@
       "District": "Legislative District 41"
     },
     {
-      "ID": 407,
+      "ID": 406,
       "Name": "Jill Reid Cummins",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 6"
     },
     {
-      "ID": 406,
+      "ID": 407,
       "Name": "Jill Reid Cummins",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -13250,7 +13110,7 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Jim Crawford",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13292,14 +13152,14 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Jim Jaramillo",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Jim Jester",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13376,7 +13236,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Jim \"Snake\" Robertson",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -13390,7 +13250,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 736,
+      "ID": 729,
       "Name": "Jim Wass",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13404,7 +13264,7 @@
       "District": "Charles County"
     },
     {
-      "ID": 747,
+      "ID": 740,
       "Name": "J. Michael Collins",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -13418,21 +13278,21 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Joan Frances Gentile",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Joan Madewell",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "Joan Magnani",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -13453,28 +13313,28 @@
       "District": "Legislative District 35A"
     },
     {
-      "ID": 652,
+      "ID": 649,
       "Name": "Jocelyn Irene Collins",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 23B"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Jodi Stanalonis",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 671,
+      "ID": 666,
       "Name": "Jody Jan Oliver",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Jody Schulz",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13488,14 +13348,14 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 740,
+      "ID": 733,
       "Name": "Joe Collins, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Joe Crawford",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13509,14 +13369,14 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Joe DiMarco",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Joe Fleckenstein",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13565,7 +13425,7 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Joe Parsley",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13579,7 +13439,7 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Joe Richards",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13621,14 +13481,14 @@
       "District": "Councilmanic District B"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Joeylynn Hough",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "John A. Robertson",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -13642,14 +13502,14 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 743,
+      "ID": 736,
       "Name": "John C. Gordon",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 741,
+      "ID": 734,
       "Name": "John C. Lerch, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -13691,14 +13551,14 @@
       "District": "Legislative District 27"
     },
     {
-      "ID": 690,
+      "ID": 685,
       "Name": "John E. Dixon, III",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 654,
+      "ID": 651,
       "Name": "John E. Richardson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13740,7 +13600,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "John J. Cierniak",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13754,7 +13614,7 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "John Lang, III",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -13782,7 +13642,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "John Michael Fetchero",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13845,14 +13705,14 @@
       "District": "Commissioner District 3"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "John Palmer",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 739,
+      "ID": 732,
       "Name": "John Philip Cabrera",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13887,7 +13747,7 @@
       "District": "Legislative District 31B"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "John Robert Emerick",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13901,7 +13761,7 @@
       "District": "Congressional District 3"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "John T. Bullock",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13915,28 +13775,28 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "John T. Carroll, Jr.",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Kent County"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "John T. McQueeney",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 655,
+      "ID": 652,
       "Name": "John T. Mitchell",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 26"
     },
     {
-      "ID": 709,
+      "ID": 703,
       "Name": "John Trevor Wingrove, Sr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -13957,7 +13817,7 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "John W. Egan",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -13978,14 +13838,14 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 750,
+      "ID": 743,
       "Name": "Jonah Jarosz",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 6"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Jonah Seth Eisenberg",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -14013,14 +13873,14 @@
       "District": "Legislative District 25"
     },
     {
-      "ID": 388,
+      "ID": 389,
       "Name": "Jonathan G. Newell",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 2"
     },
     {
-      "ID": 389,
+      "ID": 388,
       "Name": "Jonathan G. Newell",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -14048,14 +13908,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Jon Herbst",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 11"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Jonny Johnston",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14076,16 +13936,16 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 143,
+      "ID": 765,
       "Name": "Jordan Cooper",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 16"
     },
     {
-      "ID": 772,
+      "ID": 143,
       "Name": "Jordan Cooper",
-      "Contest": "Democratic Central Committee Male",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 16"
     },
@@ -14097,7 +13957,7 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Jordan Glassman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14132,7 +13992,7 @@
       "District": "Legislative District 21"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Joseph A. Groves",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14153,7 +14013,7 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 753,
+      "ID": 746,
       "Name": "Joseph C. Brown",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -14181,16 +14041,16 @@
       "District": "Talbot County"
     },
     {
-      "ID": 54,
+      "ID": 724,
       "Name": "Josephine J. Wang",
-      "Contest": "State Senator",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
     {
-      "ID": 730,
+      "ID": 54,
       "Name": "Josephine J. Wang",
-      "Contest": "Republican Central Committee",
+      "Contest": "State Senator",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
@@ -14202,7 +14062,7 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 749,
+      "ID": 742,
       "Name": "Joseph L. Aston",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -14223,21 +14083,21 @@
       "District": "Commissioner District 7"
     },
     {
-      "ID": 727,
+      "ID": 721,
       "Name": "Joseph P. Gillin",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 14"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Josh Cramer",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Josh Friedman",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -14265,21 +14125,21 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Joshua Crockett",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 787,
+      "ID": 780,
       "Name": "Joshua M. Thomas",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 2"
     },
     {
-      "ID": 752,
+      "ID": 745,
       "Name": "Joshua Wolf",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -14293,7 +14153,7 @@
       "District": "Harford County"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Jo Wanda Strickland Lucas",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14307,7 +14167,7 @@
       "District": "Legislative District 41"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Joyce M. Little",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14321,7 +14181,7 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "\"J.P.\" Sherkus",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14342,7 +14202,7 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Juan Miguel Cardenas",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
@@ -14356,14 +14216,14 @@
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 760,
+      "ID": 753,
       "Name": "Judith Ann Stephenson",
       "Contest": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 672,
+      "ID": 667,
       "Name": "Judith C. Reveal",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14391,13 +14251,6 @@
       "District": "Worcester County"
     },
     {
-      "ID": 410,
-      "Name": "Judy Lynn Woodall",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 7"
-    },
-    {
       "ID": 411,
       "Name": "Judy Lynn Woodall",
       "Contest": "Judge of the Circuit Court",
@@ -14405,7 +14258,14 @@
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 684,
+      "ID": 410,
+      "Name": "Judy Lynn Woodall",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7"
+    },
+    {
+      "ID": 679,
       "Name": "Judy Wixted",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14468,7 +14328,7 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Julie D. Brewington",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14482,7 +14342,7 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 795,
+      "ID": 788,
       "Name": "Julie K. Hummer",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -14503,7 +14363,7 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Julie Reiley",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -14511,13 +14371,6 @@
     },
     {
       "ID": 641,
-      "Name": "Julie Sugar",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 7"
-    },
-    {
-      "ID": 642,
       "Name": "Julie Sugar",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14538,7 +14391,7 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "June L. Orsillo",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -14552,7 +14405,7 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "Justinian Dispenza",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -14573,7 +14426,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Justin Mudgett",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14587,14 +14440,14 @@
       "District": "Legislative District 5"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Justin W. Chappell",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 788,
+      "ID": 781,
       "Name": "Juwan Blocker",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -14608,21 +14461,21 @@
       "District": "Frederick County"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Kaitlynn Sumpter",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Kalman Finkelstein",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 674,
+      "ID": 669,
       "Name": "Kara Welker",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14643,7 +14496,7 @@
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Karen Dacey",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14664,7 +14517,7 @@
       "District": "Councilmanic District C"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Karen Leatherwood",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14692,14 +14545,14 @@
       "District": "Legislative District 31B"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Karen P. Wathen",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Karenthia A. Barber",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14713,14 +14566,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Karen Yoho",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Karla Silvestre",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -14741,14 +14594,14 @@
       "District": "Cecil County"
     },
     {
-      "ID": 757,
+      "ID": 750,
       "Name": "Kasezga Tembo",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 12"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Kashawna Duncan",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14762,18 +14615,18 @@
       "District": "Legislative District 11"
     },
     {
-      "ID": 710,
-      "Name": "Katherine Adelaide",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Carroll County"
-    },
-    {
       "ID": 355,
       "Name": "Katherine Adelaide",
       "Contest": "County Commissioner",
       "Jurisdiction": "Carroll County",
       "District": "Commissioner District 1"
+    },
+    {
+      "ID": 704,
+      "Name": "Katherine Adelaide",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County"
     },
     {
       "ID": 505,
@@ -14783,7 +14636,7 @@
       "District": "Queen Anne's County"
     },
     {
-      "ID": 673,
+      "ID": 668,
       "Name": "Katherine Fisher Shaw",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14797,7 +14650,7 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Katherine M. Babiak",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -14811,14 +14664,14 @@
       "District": "Talbot County"
     },
     {
-      "ID": 748,
+      "ID": 741,
       "Name": "Kathleen A. Smero",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "Kathleen Causey",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -14874,28 +14727,28 @@
       "District": "Judicial Circuit 1"
     },
     {
-      "ID": 673,
+      "ID": 668,
       "Name": "Kathleen M. Sanner",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 671,
+      "ID": 666,
       "Name": "Kathleen Powell",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Kathleen Seifert",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 796,
+      "ID": 789,
       "Name": "Kathleen White",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -14909,16 +14762,16 @@
       "District": "Calvert County"
     },
     {
-      "ID": 714,
+      "ID": 227,
       "Name": "Kathy Afzali",
-      "Contest": "Republican Central Committee",
+      "Contest": "County Executive",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 227,
+      "ID": 708,
       "Name": "Kathy Afzali",
-      "Contest": "County Executive",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
@@ -14951,7 +14804,7 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 663,
+      "ID": 658,
       "Name": "Katie Dott",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14965,7 +14818,7 @@
       "District": "Legislative District 9"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Katie Stickel",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -14986,20 +14839,13 @@
       "District": "Talbot County"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Keenen Geter",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 40"
     },
     {
-      "ID": 196,
-      "Name": "Keirien Taylor",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
       "ID": 198,
       "Name": "Keirien Taylor",
       "Contest": "House of Delegates",
@@ -15015,20 +14861,6 @@
     },
     {
       "ID": 196,
-      "Name": "Keirien Taylor",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
-      "ID": 197,
-      "Name": "Keirien Taylor",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
-      "ID": 198,
       "Name": "Keirien Taylor",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
@@ -15042,13 +14874,6 @@
       "District": "Somerset County"
     },
     {
-      "ID": 665,
-      "Name": "Keith E. Haynes",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 44A"
-    },
-    {
       "ID": 215,
       "Name": "Keith E. Haynes",
       "Contest": "House of Delegates",
@@ -15056,7 +14881,14 @@
       "District": "Legislative District 44A"
     },
     {
-      "ID": 664,
+      "ID": 660,
+      "Name": "Keith E. Haynes",
+      "Contest": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44A"
+    },
+    {
+      "ID": 659,
       "Name": "Keith Holt",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15077,7 +14909,7 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 699,
+      "ID": 694,
       "Name": "Ken Ballard",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -15112,23 +14944,23 @@
       "District": "Legislative District 3B"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Kenneth A. Kiler",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 636,
+      "ID": 160,
       "Name": "Kent Roberson",
-      "Contest": "Democratic Central Committee At Large",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 25"
     },
     {
-      "ID": 160,
+      "ID": 636,
       "Name": "Kent Roberson",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 25"
     },
@@ -15140,14 +14972,14 @@
       "District": "Legislative District 35A"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Kevin B. Emmerich",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Kevin Brooks",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15161,7 +14993,7 @@
       "District": "Dorchester County"
     },
     {
-      "ID": 720,
+      "ID": 714,
       "Name": "Kevin Cioppa",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15175,7 +15007,7 @@
       "District": "Legislative District 14"
     },
     {
-      "ID": 727,
+      "ID": 721,
       "Name": "Kevin Dorrance",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15196,14 +15028,14 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 406,
+      "ID": 407,
       "Name": "Kevin G. Hessler",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 6"
     },
     {
-      "ID": 407,
+      "ID": 406,
       "Name": "Kevin G. Hessler",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -15259,16 +15091,16 @@
       "District": "Queen Anne's County"
     },
     {
-      "ID": 651,
+      "ID": 157,
       "Name": "Kevin Samuel Thomas",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 23A"
     },
     {
-      "ID": 157,
+      "ID": 648,
       "Name": "Kevin Samuel Thomas",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 23A"
     },
@@ -15287,7 +15119,7 @@
       "District": "Cecil County"
     },
     {
-      "ID": 697,
+      "ID": 692,
       "Name": "Kevin Woodward",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -15301,14 +15133,14 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Khalilah M. Harris",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 43"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Kimberly Ann Hay",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -15322,7 +15154,7 @@
       "District": "Queen Anne's County"
     },
     {
-      "ID": 750,
+      "ID": 743,
       "Name": "Kimberly Klacik",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -15336,14 +15168,14 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 672,
+      "ID": 667,
       "Name": "Kim Carlson",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Caroline County"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Kim L. Williams",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -15385,7 +15217,7 @@
       "District": "Legislative District 38A"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Kirsten Allen",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15406,7 +15238,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 669,
+      "ID": 664,
       "Name": "Kristen Franklin",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15448,21 +15280,21 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Kurt Kennedy",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 718,
+      "ID": 712,
       "Name": "Kyle Durham",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Kent County"
     },
     {
-      "ID": 665,
+      "ID": 660,
       "Name": "Kyle Samuel Berkley",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15511,7 +15343,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Larry Foster",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -15525,21 +15357,21 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 729,
+      "ID": 723,
       "Name": "Larry Lesser",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 16"
     },
     {
-      "ID": 701,
+      "ID": 696,
       "Name": "Larry N. Barron",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 758,
+      "ID": 751,
       "Name": "Larry O. Wardlow, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -15553,18 +15385,18 @@
       "District": "Legislative District 13"
     },
     {
-      "ID": 724,
-      "Name": "Larry W. Dodd",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Wicomico County"
-    },
-    {
       "ID": 306,
       "Name": "Larry W. Dodd",
       "Contest": "County Council",
       "Jurisdiction": "Wicomico County",
       "District": "Councilmanic District 3"
+    },
+    {
+      "ID": 718,
+      "Name": "Larry W. Dodd",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County"
     },
     {
       "ID": 159,
@@ -15581,14 +15413,14 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 799,
+      "ID": 792,
       "Name": "Laticia Hicks",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Latina \"Tina\" Wilson",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -15609,21 +15441,21 @@
       "District": "Talbot County"
     },
     {
-      "ID": 682,
+      "ID": 677,
       "Name": "Laura Hart",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 760,
+      "ID": 753,
       "Name": "Laura Henderson",
       "Contest": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Laura M. Walsh",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15637,7 +15469,7 @@
       "District": "Queen Anne's County"
     },
     {
-      "ID": 784,
+      "ID": 777,
       "Name": "Laura Simon",
       "Contest": "Board of Education",
       "Jurisdiction": "Montgomery County",
@@ -15651,7 +15483,7 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Lauren Beacham",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -15672,7 +15504,7 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Lauretta M. Miles",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -15686,25 +15518,18 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Laurie Plemons",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Lawrence Del Prete",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
-    },
-    {
-      "ID": 397,
-      "Name": "Lawrence F. Kreis, Jr.",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 3"
     },
     {
       "ID": 396,
@@ -15714,7 +15539,14 @@
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 710,
+      "ID": 397,
+      "Name": "Lawrence F. Kreis, Jr.",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3"
+    },
+    {
+      "ID": 704,
       "Name": "Lawrence W. Helminiak",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15735,7 +15567,7 @@
       "District": "Legislative District 21"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Lee Sachs",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15749,7 +15581,7 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 665,
+      "ID": 660,
       "Name": "Lela Campbell",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15763,7 +15595,7 @@
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Lenny Proctor",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -15784,7 +15616,7 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 684,
+      "ID": 679,
       "Name": "Lesley Israel",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -15798,14 +15630,14 @@
       "District": "Legislative District 39"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Leslie Coker",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 729,
+      "ID": 723,
       "Name": "Leslie Grizzard",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15833,7 +15665,7 @@
       "District": "Howard County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Lewis O. Saunders",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -15875,7 +15707,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 741,
+      "ID": 734,
       "Name": "Liliana Pulvirenti",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -15889,11 +15721,18 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 681,
+      "ID": 676,
       "Name": "Linda Coveleskie",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
+    },
+    {
+      "ID": 644,
+      "Name": "Linda Dorsey-Walker",
+      "Contest": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11"
     },
     {
       "ID": 133,
@@ -15903,21 +15742,14 @@
       "District": "Legislative District 11"
     },
     {
-      "ID": 645,
-      "Name": "Linda Dorsey-Walker",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 11"
-    },
-    {
-      "ID": 763,
+      "ID": 756,
       "Name": "Linda K. Foley",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 15"
     },
     {
-      "ID": 767,
+      "ID": 760,
       "Name": "Linda L. Mahoney",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -15931,28 +15763,21 @@
       "District": "Worcester County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Linda Raye Luffman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Linda Stine Flint",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 649,
-      "Name": "Linda T. Diasgranados",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 648,
+      "ID": 646,
       "Name": "Linda T. Diasgranados",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -15966,21 +15791,21 @@
       "District": "Legislative District 18"
     },
     {
-      "ID": 731,
+      "ID": 725,
       "Name": "Linda Willard",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 18"
     },
     {
-      "ID": 674,
+      "ID": 669,
       "Name": "Lindsay Bergman-Debes",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
     },
     {
-      "ID": 693,
+      "ID": 688,
       "Name": "Lindsy E. Pack",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -15994,7 +15819,7 @@
       "District": "Legislative District 45"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Linzy Jackson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16008,7 +15833,7 @@
       "District": "Somerset County"
     },
     {
-      "ID": 792,
+      "ID": 785,
       "Name": "Lisa A. Mack",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -16029,7 +15854,7 @@
       "District": "Harford County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Lisa James-Henson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16064,14 +15889,14 @@
       "District": "Talbot County"
     },
     {
-      "ID": 759,
+      "ID": 752,
       "Name": "Lisa Oliveras-Carper",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 14"
     },
     {
-      "ID": 743,
+      "ID": 736,
       "Name": "Lisa Robin Lederman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -16085,7 +15910,7 @@
       "District": "Garrett County"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Liz Barrett",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -16113,7 +15938,7 @@
       "District": "Charles County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Loretta H. Shields",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16127,7 +15952,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Loretta Spinuzza",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16141,7 +15966,7 @@
       "District": "Legislative District 20"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Lori Jaffe",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -16155,21 +15980,21 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Lorraine Kuchmy",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 715,
+      "ID": 709,
       "Name": "Luanne Ruddell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Garrett County"
     },
     {
-      "ID": 765,
+      "ID": 758,
       "Name": "Luisa Arevalo",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -16183,14 +16008,14 @@
       "District": "Legislative District 46"
     },
     {
-      "ID": 787,
+      "ID": 780,
       "Name": "Lupi Grady",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 2"
     },
     {
-      "ID": 651,
+      "ID": 648,
       "Name": "Lydia Zhemile Daniel",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16204,14 +16029,14 @@
       "District": "Cecil County"
     },
     {
-      "ID": 784,
+      "ID": 777,
       "Name": "Lynn Amano",
       "Contest": "Board of Education",
       "Jurisdiction": "Montgomery County",
       "District": "Board of Education District 3"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Lynn Corbman Scott",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16225,7 +16050,7 @@
       "District": "Legislative District 27A"
     },
     {
-      "ID": 681,
+      "ID": 676,
       "Name": "Lynn M. Mason",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -16260,7 +16085,7 @@
       "District": "Commissioner District 6"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Mae A. Beale",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -16274,7 +16099,7 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Maggi Hays",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -16288,13 +16113,6 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 409,
-      "Name": "Makeba Gibbs",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 7"
-    },
-    {
       "ID": 408,
       "Name": "Makeba Gibbs",
       "Contest": "Judge of the Circuit Court",
@@ -16302,14 +16120,21 @@
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 796,
+      "ID": 409,
+      "Name": "Makeba Gibbs",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7"
+    },
+    {
+      "ID": 789,
       "Name": "Makeda Scott",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 756,
+      "ID": 749,
       "Name": "Makelle Collins",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -16379,14 +16204,14 @@
       "District": "Legislative District 16"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Marc Morrison",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 729,
+      "ID": 723,
       "Name": "Marcus Alzona",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16407,14 +16232,14 @@
       "District": "Howard County"
     },
     {
-      "ID": 653,
+      "ID": 650,
       "Name": "Margaret A. Boles",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 24"
     },
     {
-      "ID": 643,
+      "ID": 642,
       "Name": "Margaret A. Forte",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16449,42 +16274,42 @@
       "District": "Carroll County"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Margaret T. Marshall",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Margaret Weinstein",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Margie Fleming Brinkley",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 683,
+      "ID": 678,
       "Name": "Margo Green-Gale",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Somerset County"
     },
     {
-      "ID": 403,
+      "ID": 402,
       "Name": "Maria L. Oesterreicher",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 402,
+      "ID": 403,
       "Name": "Maria L. Oesterreicher",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -16505,28 +16330,28 @@
       "District": "Legislative District 19"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Marie Fischer-Wyrick",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 760,
+      "ID": 753,
       "Name": "Marie Kathleen Mapes",
       "Contest": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
       "District": "Montgomery County"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Mari Lee",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Marilee Lum Kerns",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16554,14 +16379,14 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 681,
+      "ID": 676,
       "Name": "Marion Grier",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 760,
+      "ID": 753,
       "Name": "Marjorie Goldman",
       "Contest": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
@@ -16575,7 +16400,7 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Mark A. Regal",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16596,14 +16421,14 @@
       "District": "Legislative District 32"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Mark Edelson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Mark G. McIver",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16680,7 +16505,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Mark Uncapher",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -16736,13 +16561,6 @@
       "District": "Legislative District 45"
     },
     {
-      "ID": 732,
-      "Name": "Martha Schaerr",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 19"
-    },
-    {
       "ID": 150,
       "Name": "Martha Schaerr",
       "Contest": "House of Delegates",
@@ -16750,14 +16568,21 @@
       "District": "Legislative District 19"
     },
     {
-      "ID": 667,
+      "ID": 726,
+      "Name": "Martha Schaerr",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19"
+    },
+    {
+      "ID": 662,
       "Name": "Martin Edward Davis",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 760,
+      "ID": 753,
       "Name": "Martine Laney",
       "Contest": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
@@ -16785,7 +16610,7 @@
       "District": "Legislative District 23B"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Marwa Omar Ibrahim",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -16806,7 +16631,7 @@
       "District": "Harford County"
     },
     {
-      "ID": 685,
+      "ID": 680,
       "Name": "Mary Ann Keyser",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -16834,28 +16659,28 @@
       "District": "Allegany County"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Mary Burgess",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Worcester County"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Mary Caroline Milam",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Mary Catherine Cochran",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 671,
+      "ID": 666,
       "Name": "Mary Conlon",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -16876,18 +16701,11 @@
       "District": "Legislative District 12"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Mary Kowalski",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
-    },
-    {
-      "ID": 407,
-      "Name": "Marylin Pierre",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 6"
     },
     {
       "ID": 406,
@@ -16897,21 +16715,28 @@
       "District": "Judicial Circuit 6"
     },
     {
-      "ID": 661,
+      "ID": 407,
+      "Name": "Marylin Pierre",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6"
+    },
+    {
+      "ID": 656,
       "Name": "Mary Page Michel",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 386,
+      "ID": 387,
       "Name": "Mary \"Peggy\" Kent",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 1"
     },
     {
-      "ID": 387,
+      "ID": 386,
       "Name": "Mary \"Peggy\" Kent",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -16925,7 +16750,7 @@
       "District": "Legislative District 30A"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Mary Rolle",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16946,21 +16771,21 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 781,
+      "ID": 774,
       "Name": "Masai M. Troutman",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 721,
+      "ID": 715,
       "Name": "Matt Adams",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Somerset County"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Matt Albers",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -16988,25 +16813,18 @@
       "District": "Legislative District 21"
     },
     {
-      "ID": 790,
+      "ID": 783,
       "Name": "Matt Green",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 9"
     },
     {
-      "ID": 792,
+      "ID": 785,
       "Name": "Matt Gresick",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 1"
-    },
-    {
-      "ID": 385,
-      "Name": "Matthew A. Maciarello",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 1"
     },
     {
       "ID": 384,
@@ -17016,28 +16834,35 @@
       "District": "Judicial Circuit 1"
     },
     {
-      "ID": 721,
+      "ID": 385,
+      "Name": "Matthew A. Maciarello",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1"
+    },
+    {
+      "ID": 715,
       "Name": "Matthew C. Powell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Somerset County"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Matthew Davidson",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "Matthew D. Walls",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Kent County"
     },
     {
-      "ID": 653,
+      "ID": 650,
       "Name": "Matthew Fogg",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17051,28 +16876,28 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 773,
+      "ID": 766,
       "Name": "Matthew Lee",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 17"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Matthew Molyett",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Matthew Resnik",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 690,
+      "ID": 685,
       "Name": "Matthew Welch",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -17093,7 +16918,7 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Maura Cleary Dunnigan",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -17121,14 +16946,14 @@
       "District": "Caroline County"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Maureen Evans Arthurs",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Maureen Janette Woodruff",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17156,7 +16981,7 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Mavourene Robinson",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -17170,7 +16995,7 @@
       "District": "Legislative District 8"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Max Green",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17205,11 +17030,18 @@
       "District": "Frederick County"
     },
     {
-      "ID": 751,
+      "ID": 744,
       "Name": "Megan Oliveras-Conners",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 7"
+    },
+    {
+      "ID": 734,
+      "Name": "Melanie Harris",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1"
     },
     {
       "ID": 135,
@@ -17217,13 +17049,6 @@
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 12"
-    },
-    {
-      "ID": 741,
-      "Name": "Melanie Harris",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 1"
     },
     {
       "ID": 259,
@@ -17247,14 +17072,14 @@
       "District": "Frederick County"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Melissa Davis",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 795,
+      "ID": 788,
       "Name": "Melissa Ellis",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -17303,7 +17128,7 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "Melvin S. Rapelyea",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -17324,14 +17149,14 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 669,
+      "ID": 664,
       "Name": "Micah Watson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 47A"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Michael Aaron Rosenblum",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17408,14 +17233,14 @@
       "District": "Legislative District 9A"
     },
     {
-      "ID": 698,
+      "ID": 693,
       "Name": "Michael D. Brown",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Michael D. Hill",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17457,7 +17282,7 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Michael Eisenberg",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17471,14 +17296,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 395,
+      "ID": 394,
       "Name": "Michael Finifter",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 394,
+      "ID": 395,
       "Name": "Michael Finifter",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -17499,7 +17324,7 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Michael Higgs",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -17527,39 +17352,18 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 197,
+      "ID": 198,
       "Name": "Michael Ian Welker",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 36"
     },
     {
-      "ID": 690,
+      "ID": 685,
       "Name": "Michael Ian Welker",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
-    },
-    {
-      "ID": 196,
-      "Name": "Michael Ian Welker",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
-      "ID": 198,
-      "Name": "Michael Ian Welker",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
-    },
-    {
-      "ID": 198,
-      "Name": "Michael Ian Welker",
-      "Contest": "House of Delegates",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 36"
     },
     {
       "ID": 324,
@@ -17576,28 +17380,28 @@
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Michael L. Sowell",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 643,
+      "ID": 642,
       "Name": "Michael Matthew Manning, Jr.",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 8"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Michael May",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 40"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Michael \"Mike\" Lukas",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -17611,13 +17415,6 @@
       "District": "Allegany County"
     },
     {
-      "ID": 757,
-      "Name": "Michael Pearson",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 12"
-    },
-    {
       "ID": 21,
       "Name": "Michael Pearson",
       "Contest": "Representative in Congress",
@@ -17625,7 +17422,14 @@
       "District": "Congressional District 7"
     },
     {
-      "ID": 794,
+      "ID": 750,
+      "Name": "Michael Pearson",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 12"
+    },
+    {
+      "ID": 787,
       "Name": "Michael Petrella",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -17653,7 +17457,7 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 774,
+      "ID": 767,
       "Name": "Michael Tardif",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -17667,21 +17471,21 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "Michael V. Voelker",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Michael W. Brady",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Michael W. Dawson",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17695,7 +17499,7 @@
       "District": "Cecil County"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Michael Yokay",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -17723,7 +17527,7 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 686,
+      "ID": 681,
       "Name": "Michele Gregory",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -17744,14 +17548,14 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 737,
+      "ID": 730,
       "Name": "Michele Speakman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32"
     },
     {
-      "ID": 793,
+      "ID": 786,
       "Name": "Michelle Bradley",
       "Contest": "Board of Education",
       "Jurisdiction": "Wicomico County",
@@ -17765,7 +17569,7 @@
       "District": "Legislative District 18"
     },
     {
-      "ID": 799,
+      "ID": 792,
       "Name": "Michelle Corkadel",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -17779,7 +17583,7 @@
       "District": "Legislative District 21"
     },
     {
-      "ID": 760,
+      "ID": 753,
       "Name": "Michelle Ngwafon",
       "Contest": "Democratic Central Committee Female At Large",
       "Jurisdiction": "State of Maryland",
@@ -17793,14 +17597,14 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Mike Arntz",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Mike Ball",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17814,7 +17618,7 @@
       "District": "Legislative District 3A"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Mike Bracknell",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -17856,14 +17660,14 @@
       "District": "Calvert County"
     },
     {
-      "ID": 702,
+      "ID": 697,
       "Name": "Mike Folkoff",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Mike Griffith",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17926,7 +17730,7 @@
       "District": "Legislative District 18"
     },
     {
-      "ID": 762,
+      "ID": 755,
       "Name": "Mimi Hassanein",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -17947,7 +17751,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 689,
+      "ID": 684,
       "Name": "Mitch Edelman",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -17961,7 +17765,7 @@
       "District": "Congressional District 2"
     },
     {
-      "ID": 745,
+      "ID": 738,
       "Name": "M.J. Madwolf",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -17982,7 +17786,7 @@
       "District": "Legislative District 34A"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Monica Cooper",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -17996,14 +17800,14 @@
       "District": "Talbot County"
     },
     {
-      "ID": 786,
+      "ID": 779,
       "Name": "Monica L. Rinker",
       "Contest": "Board of Education",
       "Jurisdiction": "Garrett County",
       "District": "Commissioner District 3"
     },
     {
-      "ID": 651,
+      "ID": 648,
       "Name": "Monica Roebuck",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18017,42 +17821,42 @@
       "District": "Councilmanic District 8"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Morgan Dowell",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 10"
     },
     {
-      "ID": 707,
-      "Name": "Morgan Mayer",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Allegany County"
-    },
-    {
-      "ID": 778,
+      "ID": 771,
       "Name": "Morgan Mayer",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 724,
+      "ID": 701,
+      "Name": "Morgan Mayer",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County"
+    },
+    {
+      "ID": 718,
       "Name": "Muir Boda",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 777,
+      "ID": 770,
       "Name": "Mumin Barre",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Muri Dueppen",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -18066,14 +17870,14 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Najee Bailey",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 680,
+      "ID": 675,
       "Name": "Nancy I. Smith",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -18115,7 +17919,7 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Nashonda Sherrod",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -18129,7 +17933,7 @@
       "District": "Legislative District 9A"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Natasza Bock-Singleton",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18143,7 +17947,7 @@
       "District": "Legislative District 46"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Nate Sansom",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18178,16 +17982,16 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 661,
+      "ID": 94,
       "Name": "Nathaniel T. Oaks",
-      "Contest": "Democratic Central Committee",
+      "Contest": "State Senator",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 94,
+      "ID": 656,
       "Name": "Nathaniel T. Oaks",
-      "Contest": "State Senator",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
@@ -18199,7 +18003,7 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 666,
+      "ID": 661,
       "Name": "Nayna C. Philipsen",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18248,14 +18052,14 @@
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Nicholas Adam Cathell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "Nicholas A. Panuzio",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18269,11 +18073,18 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Nicholas T. Hadley",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
+    },
+    {
+      "ID": 733,
+      "Name": "Nicholas Wentworth",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 1"
     },
     {
       "ID": 220,
@@ -18281,13 +18092,6 @@
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
-    },
-    {
-      "ID": 740,
-      "Name": "Nicholas Wentworth",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore City",
-      "District": "Councilmanic District 1"
     },
     {
       "ID": 181,
@@ -18304,14 +18108,14 @@
       "District": "Legislative District 25"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Nick DePaulo",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Calvert County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Nick Frisone",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18339,7 +18143,7 @@
       "District": "Legislative District 22"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Nicole Bennett",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18360,14 +18164,14 @@
       "District": "Worcester County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Nicole Hanson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 45"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Nikki S. Randolph",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18381,7 +18185,7 @@
       "District": "Legislative District 43"
     },
     {
-      "ID": 643,
+      "ID": 642,
       "Name": "Nina McHugh",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18402,32 +18206,25 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 706,
+      "ID": 700,
       "Name": "Noah Stewart",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 33"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Noel Levy",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 11"
     },
     {
-      "ID": 655,
+      "ID": 652,
       "Name": "Nora E. Carmichael",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 26"
-    },
-    {
-      "ID": 750,
-      "Name": "Norma Secoura",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 6"
     },
     {
       "ID": 126,
@@ -18437,6 +18234,13 @@
       "District": "Legislative District 8"
     },
     {
+      "ID": 743,
+      "Name": "Norma Secoura",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 6"
+    },
+    {
       "ID": 124,
       "Name": "Norm Gifford",
       "Contest": "House of Delegates",
@@ -18444,7 +18248,7 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 654,
+      "ID": 651,
       "Name": "Nova Coston",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18472,7 +18276,7 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Odette Ramos",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18500,28 +18304,28 @@
       "District": "Legislative District 32"
     },
     {
-      "ID": 788,
+      "ID": 781,
       "Name": "Pamela Boozer-Strother",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 3"
     },
     {
-      "ID": 714,
+      "ID": 708,
       "Name": "Pamela Ciliberti",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 768,
+      "ID": 761,
       "Name": "Pamela Francine Luckett",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 20"
     },
     {
-      "ID": 680,
+      "ID": 675,
       "Name": "Pamela L. White",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -18535,7 +18339,7 @@
       "District": "Legislative District 14"
     },
     {
-      "ID": 685,
+      "ID": 680,
       "Name": "Pam Faulkner",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -18549,21 +18353,21 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Paris Bienert",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 789,
+      "ID": 782,
       "Name": "Pat Fletcher",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
       "District": "Board of Education District 6"
     },
     {
-      "ID": 644,
+      "ID": 643,
       "Name": "Pat Kelly",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18577,18 +18381,25 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Patricia Ann Dorsey",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 674,
+      "ID": 669,
       "Name": "Patricia D. Folk",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Cecil County"
+    },
+    {
+      "ID": 720,
+      "Name": "Patricia Fenati",
+      "Contest": "Republican Central Committee At Large",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County"
     },
     {
       "ID": 140,
@@ -18598,11 +18409,11 @@
       "District": "Legislative District 14"
     },
     {
-      "ID": 726,
-      "Name": "Patricia Fenati",
-      "Contest": "Republican Central Committee At Large",
+      "ID": 650,
+      "Name": "Patricia M. Waiters",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Montgomery County"
+      "District": "Legislative District 24"
     },
     {
       "ID": 329,
@@ -18612,14 +18423,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 653,
-      "Name": "Patricia M. Waiters",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 24"
-    },
-    {
-      "ID": 784,
+      "ID": 777,
       "Name": "Patricia O'Neill",
       "Contest": "Board of Education",
       "Jurisdiction": "Montgomery County",
@@ -18633,16 +18437,16 @@
       "District": "Talbot County"
     },
     {
-      "ID": 705,
+      "ID": 183,
       "Name": "Patrick Armstrong",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32"
     },
     {
-      "ID": 183,
+      "ID": 699,
       "Name": "Patrick Armstrong",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32"
     },
@@ -18654,49 +18458,49 @@
       "District": "Calvert County"
     },
     {
-      "ID": 700,
+      "ID": 695,
       "Name": "Patrick Firth",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County"
     },
     {
-      "ID": 650,
+      "ID": 647,
       "Name": "Patrick Gallaher",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 22"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Patrick J. Haggerty, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 693,
+      "ID": 688,
       "Name": "Patrick J. Hunt",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Garrett County"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Patrick L. McGrady",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Patrick McLaughlin",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 732,
+      "ID": 726,
       "Name": "Patrick Spaulding",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18738,7 +18542,7 @@
       "District": "Legislative District 44B"
     },
     {
-      "ID": 671,
+      "ID": 666,
       "Name": "Paula Jayne Summerfield",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -18759,16 +18563,16 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 577,
+      "ID": 717,
       "Name": "Paul D. Banister",
-      "Contest": "Judge of the Orphans' Court",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 723,
+      "ID": 577,
       "Name": "Paul D. Banister",
-      "Contest": "Republican Central Committee",
+      "Contest": "Judge of the Orphans' Court",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
@@ -18780,7 +18584,7 @@
       "District": "Legislative District 2B"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "Paul Evitts",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -18801,18 +18605,18 @@
       "District": "Carroll County"
     },
     {
-      "ID": 646,
+      "ID": 645,
       "Name": "Pauline Kibby Rada",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 12"
     },
     {
-      "ID": 647,
-      "Name": "Pauline Kibby Rada",
-      "Contest": "Democratic Central Committee",
+      "ID": 684,
+      "Name": "Paul Johnson",
+      "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 12"
+      "District": "Carroll County"
     },
     {
       "ID": 370,
@@ -18822,13 +18626,6 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 689,
-      "Name": "Paul Johnson",
-      "Contest": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Carroll County"
-    },
-    {
       "ID": 158,
       "Name": "Paul Manicone",
       "Contest": "House of Delegates",
@@ -18836,7 +18633,7 @@
       "District": "Legislative District 23B"
     },
     {
-      "ID": 752,
+      "ID": 745,
       "Name": "Paul M. Blitz",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -18864,7 +18661,7 @@
       "District": "Talbot County"
     },
     {
-      "ID": 729,
+      "ID": 723,
       "Name": "Paul S. Foldi",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18878,21 +18675,21 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 794,
+      "ID": 787,
       "Name": "Paul V. Konka",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 396,
+      "ID": 397,
       "Name": "Paul W. Ishak",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 397,
+      "ID": 396,
       "Name": "Paul W. Ishak",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -18927,14 +18724,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Pernevlyn C. Coggins",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Perrice U. Austin",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -18948,7 +18745,7 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 792,
+      "ID": 785,
       "Name": "Pete Fitzpatrick",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -18976,7 +18773,7 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 741,
+      "ID": 734,
       "Name": "Pete Melcavage, II",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -18990,18 +18787,18 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 701,
-      "Name": "Peter E. Perini, Sr.",
-      "Contest": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Washington County"
-    },
-    {
       "ID": 111,
       "Name": "Peter E. Perini, Sr.",
       "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 2B"
+    },
+    {
+      "ID": 696,
+      "Name": "Peter E. Perini, Sr.",
+      "Contest": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County"
     },
     {
       "ID": 3,
@@ -19011,14 +18808,14 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 411,
+      "ID": 410,
       "Name": "Peter Killough",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 410,
+      "ID": 411,
       "Name": "Peter Killough",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -19032,7 +18829,7 @@
       "District": "Charles County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Peter Spann",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -19081,7 +18878,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Phylicia Porter",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19095,7 +18892,7 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Pravin Ponnuri",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -19109,14 +18906,14 @@
       "District": "Commissioner District 7"
     },
     {
-      "ID": 705,
+      "ID": 699,
       "Name": "Quincy Bareebe",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 32"
     },
     {
-      "ID": 684,
+      "ID": 679,
       "Name": "Rachel L. Gallagher",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -19137,7 +18934,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 739,
+      "ID": 732,
       "Name": "Ramana Raju Sarikonda",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19151,7 +18948,7 @@
       "District": "Washington County"
     },
     {
-      "ID": 701,
+      "ID": 696,
       "Name": "Randy Barber",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -19179,14 +18976,14 @@
       "District": "Commissioner District 5"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Randy Leatherman",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 673,
+      "ID": 668,
       "Name": "Raquel Walsh",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -19200,42 +18997,42 @@
       "District": "Congressional District 7"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Ray Davis",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 43"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Ray Edward Foltz, Sr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Rayelle Davis",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 799,
+      "ID": 792,
       "Name": "Ray Leone",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 666,
+      "ID": 661,
       "Name": "Raymond Briggs",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44B"
     },
     {
-      "ID": 745,
+      "ID": 738,
       "Name": "Raymond C. Boccelli",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -19249,7 +19046,7 @@
       "District": "Legislative District 42B"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Ray Shegogue",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19263,14 +19060,14 @@
       "District": "Legislative District 34A"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Reanna M. Rogers",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 43"
     },
     {
-      "ID": 728,
+      "ID": 722,
       "Name": "Reardon Sullivan",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19284,14 +19081,14 @@
       "District": "Legislative District 17"
     },
     {
-      "ID": 796,
+      "ID": 789,
       "Name": "Regina Ann Smith",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 677,
+      "ID": 672,
       "Name": "Regina Holliday",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -19305,16 +19102,16 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 562,
+      "ID": 686,
       "Name": "Reginald Kearney",
-      "Contest": "Judge of the Orphans' Court",
+      "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 691,
+      "ID": 562,
       "Name": "Reginald Kearney",
-      "Contest": "Democratic Central Committee Male",
+      "Contest": "Judge of the Orphans' Court",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
@@ -19347,14 +19144,14 @@
       "District": "Legislative District 9"
     },
     {
-      "ID": 662,
+      "ID": 657,
       "Name": "Rekha R. Rapaka",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 42A"
     },
     {
-      "ID": 676,
+      "ID": 671,
       "Name": "Renee Knapp",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -19375,42 +19172,42 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 744,
+      "ID": 737,
       "Name": "Rhandi Lawrence",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 654,
+      "ID": 651,
       "Name": "Rhonda Wallace",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 25"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Rhya Marohn",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Ricarra Jones",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 748,
+      "ID": 741,
       "Name": "Richard A. Brown",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Richard A. Romer",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19445,7 +19242,7 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 785,
+      "ID": 778,
       "Name": "Richard \"Dick\" Smith",
       "Contest": "Board of Education",
       "Jurisdiction": "Queen Anne's County",
@@ -19487,7 +19284,7 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Richard John Mulderick",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19501,7 +19298,7 @@
       "District": "Calvert County"
     },
     {
-      "ID": 792,
+      "ID": 785,
       "Name": "Richard M. Young",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -19515,7 +19312,7 @@
       "District": "State of Maryland"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Richard Rothschild",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19536,14 +19333,14 @@
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 650,
+      "ID": 647,
       "Name": "Richard Schumaker",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 22"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Rich Corkran",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -19571,13 +19368,6 @@
       "District": "Congressional District 7"
     },
     {
-      "ID": 719,
-      "Name": "Rick Bowers",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Queen Anne's County"
-    },
-    {
       "ID": 195,
       "Name": "Rick Bowers",
       "Contest": "House of Delegates",
@@ -19585,11 +19375,11 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 401,
-      "Name": "Rickey Nelson Jones",
-      "Contest": "Judge of the Circuit Court",
+      "ID": 713,
+      "Name": "Rick Bowers",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 5"
+      "District": "Queen Anne's County"
     },
     {
       "ID": 400,
@@ -19599,7 +19389,14 @@
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 727,
+      "ID": 401,
+      "Name": "Rickey Nelson Jones",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5"
+    },
+    {
+      "ID": 721,
       "Name": "Rick Hansen",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19690,7 +19487,7 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 787,
+      "ID": 780,
       "Name": "Rob Anthony",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -19725,7 +19522,7 @@
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Robert A. Kurland",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19739,21 +19536,14 @@
       "District": "Legislative District 29A"
     },
     {
-      "ID": 646,
+      "ID": 645,
       "Name": "Robert Benjamin",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 12"
     },
     {
-      "ID": 647,
-      "Name": "Robert Benjamin",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 12"
-    },
-    {
-      "ID": 719,
+      "ID": 713,
       "Name": "Robert B. Mansfield",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19767,7 +19557,7 @@
       "District": "Legislative District 14"
     },
     {
-      "ID": 752,
+      "ID": 745,
       "Name": "Robert D. Schweitzer",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
@@ -19809,35 +19599,35 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Robert Michael Pitts",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 687,
+      "ID": 682,
       "Name": "Robert M. Riggs",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 697,
+      "ID": 692,
       "Name": "Robert R. Hardy, Jr.",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Robert \"Rori\" Marston",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 667,
+      "ID": 662,
       "Name": "Robert Stokes, Sr.",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19851,7 +19641,7 @@
       "District": "Councilmanic District E"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Robert Wayne Miller",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -19872,14 +19662,14 @@
       "District": "Judicial Circuit 5"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Robert W. \"Rob\" Reed",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Calvert County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Robert Yochem",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -19893,7 +19683,7 @@
       "District": "Carroll County"
     },
     {
-      "ID": 677,
+      "ID": 672,
       "Name": "Robin Bissell",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -19935,7 +19725,7 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 687,
+      "ID": 682,
       "Name": "Robin Summerfield",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -19963,7 +19753,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 800,
+      "ID": 793,
       "Name": "Rod McMillion",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
@@ -20005,16 +19795,16 @@
       "District": "Congressional District 6"
     },
     {
-      "ID": 719,
+      "ID": 505,
       "Name": "Roger Twigg",
-      "Contest": "Republican Central Committee",
+      "Contest": "Clerk of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 505,
+      "ID": 713,
       "Name": "Roger Twigg",
-      "Contest": "Clerk of the Circuit Court",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
@@ -20047,14 +19837,14 @@
       "District": "Legislative District 3"
     },
     {
-      "ID": 652,
+      "ID": 649,
       "Name": "Ronald O'Keefe",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 23B"
     },
     {
-      "ID": 687,
+      "ID": 682,
       "Name": "Ronald W. Lewis",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20124,7 +19914,7 @@
       "District": "Talbot County"
     },
     {
-      "ID": 665,
+      "ID": 660,
       "Name": "Roscoe Damon Brunson, III",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20159,7 +19949,7 @@
       "District": "Legislative District 27"
     },
     {
-      "ID": 665,
+      "ID": 660,
       "Name": "Roxane Prettyman",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20187,7 +19977,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Russell Yates",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20208,21 +19998,21 @@
       "District": "Legislative District 6"
     },
     {
-      "ID": 793,
+      "ID": 786,
       "Name": "Ruth Angelot",
       "Contest": "Board of Education",
       "Jurisdiction": "Wicomico County",
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 743,
+      "ID": 736,
       "Name": "Ruth E. Goetz",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 2"
     },
     {
-      "ID": 715,
+      "ID": 709,
       "Name": "Ruth Hinebaugh Umbel",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20243,7 +20033,7 @@
       "District": "Judicial Circuit 3"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Ryan Arbuckle",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -20257,14 +20047,14 @@
       "District": "Councilmanic District 6"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Ryan Finch",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 653,
+      "ID": 650,
       "Name": "Ryan Middleton",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20285,14 +20075,14 @@
       "District": "Legislative District 3A"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Ryan Turner",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Sabina Taj",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -20327,35 +20117,35 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Safa Hira",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Saif Rehman",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 698,
+      "ID": 693,
       "Name": "Sal Raspa",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Saint Mary's County"
     },
     {
-      "ID": 685,
+      "ID": 680,
       "Name": "Samantha Broadway",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Washington County"
     },
     {
-      "ID": 767,
+      "ID": 760,
       "Name": "Samantha Jones",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -20376,21 +20166,14 @@
       "District": "Legislative District 16"
     },
     {
-      "ID": 646,
+      "ID": 645,
       "Name": "Sam Moxley",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 12"
     },
     {
-      "ID": 647,
-      "Name": "Sam Moxley",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 12"
-    },
-    {
-      "ID": 727,
+      "ID": 721,
       "Name": "Samuel Fenati",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20411,7 +20194,7 @@
       "District": "Harford County"
     },
     {
-      "ID": 680,
+      "ID": 675,
       "Name": "Sandra H. Bjork",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -20432,7 +20215,7 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 708,
+      "ID": 702,
       "Name": "Sarah Elisabeth Rosier",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20467,21 +20250,21 @@
       "District": "Legislative District 40"
     },
     {
-      "ID": 686,
+      "ID": 681,
       "Name": "Sarah Meyers",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 671,
+      "ID": 666,
       "Name": "Sarah Parsons",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 764,
+      "ID": 757,
       "Name": "Sarah Wolek",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -20495,7 +20278,7 @@
       "District": "Legislative District 16"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Scherod Barnes",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20509,7 +20292,7 @@
       "District": "Cecil County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Scott A. Berkowitz",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20523,7 +20306,7 @@
       "District": "Washington County"
     },
     {
-      "ID": 761,
+      "ID": 754,
       "Name": "Scott E. Goldberg",
       "Contest": "Democratic Central Committee Male At Large",
       "Jurisdiction": "State of Maryland",
@@ -20544,7 +20327,7 @@
       "District": "Legislative District 31"
     },
     {
-      "ID": 700,
+      "ID": 695,
       "Name": "Scott Kane",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20572,7 +20355,7 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 662,
+      "ID": 657,
       "Name": "Scott Sokol",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20586,21 +20369,14 @@
       "District": "Worcester County"
     },
     {
-      "ID": 735,
+      "ID": 728,
       "Name": "Scott W. DiBiasio",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 21"
     },
     {
-      "ID": 734,
-      "Name": "Scott W. DiBiasio",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 797,
+      "ID": 790,
       "Name": "Seamus Benn",
       "Contest": "Board of Education",
       "Jurisdiction": "Wicomico County",
@@ -20614,13 +20390,6 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 410,
-      "Name": "Sean D. Wallace",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 7"
-    },
-    {
       "ID": 411,
       "Name": "Sean D. Wallace",
       "Contest": "Judge of the Circuit Court",
@@ -20628,7 +20397,14 @@
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 695,
+      "ID": 410,
+      "Name": "Sean D. Wallace",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7"
+    },
+    {
+      "ID": 690,
       "Name": "Sean Ford",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20642,7 +20418,7 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Sean \"Shmop\" Weisbord",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20670,14 +20446,14 @@
       "District": "Legislative District 30B"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Seth Shipley",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 723,
+      "ID": 717,
       "Name": "Seth Wilson",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20691,7 +20467,7 @@
       "District": "Legislative District 23A"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Shahan Rizvi",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20705,7 +20481,7 @@
       "District": "Baltimore City"
     },
     {
-      "ID": 698,
+      "ID": 693,
       "Name": "Shane Mattingly",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -20733,35 +20509,35 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 744,
+      "ID": 737,
       "Name": "Shannon Wright",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 669,
+      "ID": 664,
       "Name": "Shanzah Khan",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 47A"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Sharif Small",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Sharon Beam",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Harford County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Sharon Brackett",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20775,7 +20551,7 @@
       "District": "Frederick County"
     },
     {
-      "ID": 726,
+      "ID": 720,
       "Name": "Sharon L. Cohen",
       "Contest": "Republican Central Committee At Large",
       "Jurisdiction": "State of Maryland",
@@ -20803,7 +20579,7 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Shawn A. Bradley",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20824,11 +20600,18 @@
       "District": "Howard County"
     },
     {
-      "ID": 677,
+      "ID": 672,
       "Name": "Sheila R. Buckley",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Garrett County"
+    },
+    {
+      "ID": 661,
+      "Name": "Sheila Ruth",
+      "Contest": "Democratic Central Committee",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44B"
     },
     {
       "ID": 269,
@@ -20838,13 +20621,6 @@
       "District": "Councilmanic District 1"
     },
     {
-      "ID": 666,
-      "Name": "Sheila Ruth",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 44B"
-    },
-    {
       "ID": 43,
       "Name": "Sheldon H. Laskin",
       "Contest": "State Senator",
@@ -20852,7 +20628,7 @@
       "District": "Legislative District 11"
     },
     {
-      "ID": 732,
+      "ID": 726,
       "Name": "Sheldon Sacks",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20880,7 +20656,7 @@
       "District": "Legislative District 37A"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Sherelle R. Witherspoon",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20922,7 +20698,7 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 791,
+      "ID": 784,
       "Name": "Sidney A. Butcher",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -20957,7 +20733,7 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Sonja Merchant-Jones",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -20971,14 +20747,14 @@
       "District": "Talbot County"
     },
     {
-      "ID": 653,
+      "ID": 650,
       "Name": "Sonji Moore Abdullah",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 24"
     },
     {
-      "ID": 790,
+      "ID": 783,
       "Name": "Sonya Williams",
       "Contest": "Board of Education",
       "Jurisdiction": "Prince George's County",
@@ -20992,14 +20768,7 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 703,
-      "Name": "Stacy Korbelak",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 21"
-    },
-    {
-      "ID": 704,
+      "ID": 698,
       "Name": "Stacy Korbelak",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21034,14 +20803,14 @@
       "District": "Legislative District 10"
     },
     {
-      "ID": 650,
+      "ID": 647,
       "Name": "Stephanie D. Hicks",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 22"
     },
     {
-      "ID": 677,
+      "ID": 672,
       "Name": "Stephanie G. Pack",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -21069,7 +20838,7 @@
       "District": "Legislative District 42A"
     },
     {
-      "ID": 721,
+      "ID": 715,
       "Name": "Stephen G. Frey",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21083,7 +20852,7 @@
       "District": "Legislative District 42A"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Stephen Puopolo",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -21097,7 +20866,7 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Stephen Sugg",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -21111,7 +20880,7 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Steve Holt",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21125,14 +20894,14 @@
       "District": "Legislative District 34A"
     },
     {
-      "ID": 712,
+      "ID": 706,
       "Name": "Steve Mattingly",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 775,
+      "ID": 768,
       "Name": "Steven Cenname",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -21153,7 +20922,7 @@
       "District": "Legislative District 36"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Steven K. Sisk",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21167,7 +20936,7 @@
       "District": "Worcester County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "Steven Lee Sendelbach",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21202,7 +20971,7 @@
       "District": "Caroline County"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Steven Tyrone Johnson",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21223,16 +20992,16 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 709,
+      "ID": 489,
       "Name": "Steve Stouffer",
-      "Contest": "Republican Central Committee",
+      "Contest": "Clerk of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Caroline County"
     },
     {
-      "ID": 489,
+      "ID": 703,
       "Name": "Steve Stouffer",
-      "Contest": "Clerk of the Circuit Court",
+      "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Caroline County"
     },
@@ -21272,7 +21041,7 @@
       "District": "Allegany County"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "SueEllen Lawton",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21286,7 +21055,7 @@
       "District": "Congressional District 8"
     },
     {
-      "ID": 678,
+      "ID": 673,
       "Name": "Surette Davis",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -21314,7 +21083,7 @@
       "District": "Legislative District 30B"
     },
     {
-      "ID": 684,
+      "ID": 679,
       "Name": "Susan Delean-Botkin",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -21335,7 +21104,7 @@
       "District": "Legislative District 5"
     },
     {
-      "ID": 738,
+      "ID": 731,
       "Name": "Susan McConkey",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21356,7 +21125,7 @@
       "District": "Worcester County"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Susie Cunningham",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21391,35 +21160,28 @@
       "District": "Councilmanic District B"
     },
     {
-      "ID": 679,
+      "ID": 674,
       "Name": "Suzanne R. Geckle",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 721,
+      "ID": 715,
       "Name": "Suzanne Tawes Smith",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Somerset County"
     },
     {
-      "ID": 769,
+      "ID": 762,
       "Name": "Suzi Williams Kaplan",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 39"
     },
     {
-      "ID": 657,
-      "Name": "Sydney Harrison",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 27A"
-    },
-    {
-      "ID": 656,
+      "ID": 653,
       "Name": "Sydney Harrison",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21440,14 +21202,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Sylvia Williams",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 43"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Tajala \"Taj\" Battle-Lockhart",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -21468,14 +21230,14 @@
       "District": "Councilmanic District 9"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Tammy Burns",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Dorchester County"
     },
     {
-      "ID": 721,
+      "ID": 715,
       "Name": "Tammy Chaffey Truitt",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21496,14 +21258,14 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Tammy Stinnett",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 751,
+      "ID": 744,
       "Name": "Tamu Ifetayo Davenport",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -21524,35 +21286,28 @@
       "District": "Councilmanic District 9"
     },
     {
-      "ID": 779,
+      "ID": 772,
       "Name": "Tara Battaglia",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 647,
+      "ID": 645,
       "Name": "Tara Ebersole",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 12"
     },
     {
-      "ID": 646,
-      "Name": "Tara Ebersole",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 12"
-    },
-    {
-      "ID": 796,
+      "ID": 789,
       "Name": "Tara Huffman",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 4"
     },
     {
-      "ID": 718,
+      "ID": 712,
       "Name": "Tatiana Croissette",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21573,14 +21328,14 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Ted Bryant",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Dorchester County"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Ted Kolodzey",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21594,14 +21349,14 @@
       "District": "Calvert County"
     },
     {
-      "ID": 668,
+      "ID": 663,
       "Name": "Ted Walsh",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 46"
     },
     {
-      "ID": 661,
+      "ID": 656,
       "Name": "Tehila Fink",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21629,7 +21384,7 @@
       "District": "Howard County"
     },
     {
-      "ID": 664,
+      "ID": 659,
       "Name": "Terrence Thrweatt, Jr.",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21678,30 +21433,30 @@
       "District": "Caroline County"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Terry Lynn Kasecamp",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 798,
+      "ID": 791,
       "Name": "Terry R. Gilleland, Jr.",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 209,
+      "ID": 656,
       "Name": "Tessa Hill-Aston",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 661,
+      "ID": 209,
       "Name": "Tessa Hill-Aston",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
@@ -21734,14 +21489,14 @@
       "District": "Commissioner District 1"
     },
     {
-      "ID": 669,
+      "ID": 664,
       "Name": "Theresa Mitchell Dudley",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 47A"
     },
     {
-      "ID": 660,
+      "ID": 655,
       "Name": "Theresa Stegman",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21769,14 +21524,14 @@
       "District": "Legislative District 29"
     },
     {
-      "ID": 786,
+      "ID": 779,
       "Name": "Thomas Carr",
       "Contest": "Board of Education",
       "Jurisdiction": "Garrett County",
       "District": "Commissioner District 3"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Thomas Coleman Robinson, 3rd",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21804,18 +21559,11 @@
       "District": "Kent County"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Thomas Gordon Slater",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
-    },
-    {
-      "ID": 675,
-      "Name": "Thomasina \"Sina\" Coates",
-      "Contest": "Democratic Central Committee Female",
-      "Jurisdiction": "State of Maryland",
-      "District": "Charles County"
     },
     {
       "ID": 430,
@@ -21825,6 +21573,13 @@
       "District": "Commissioner District 2"
     },
     {
+      "ID": 670,
+      "Name": "Thomasina \"Sina\" Coates",
+      "Contest": "Democratic Central Committee Female",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County"
+    },
+    {
       "ID": 416,
       "Name": "Thomas J. Wilson",
       "Contest": "County Council",
@@ -21832,7 +21587,7 @@
       "District": "Councilmanic District 3"
     },
     {
-      "ID": 696,
+      "ID": 691,
       "Name": "Thomas Martin",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -21846,14 +21601,14 @@
       "District": "Calvert County"
     },
     {
-      "ID": 689,
+      "ID": 684,
       "Name": "Thomas R. Scanlan",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Thomas Stratton Gill",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -21874,7 +21629,7 @@
       "District": "Queen Anne's County"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "Thom Meads",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21888,13 +21643,6 @@
       "District": "Legislative District 24"
     },
     {
-      "ID": 410,
-      "Name": "Tiffany H. Anderson",
-      "Contest": "Judge of the Circuit Court",
-      "Jurisdiction": "State of Maryland",
-      "District": "Judicial Circuit 7"
-    },
-    {
       "ID": 411,
       "Name": "Tiffany H. Anderson",
       "Contest": "Judge of the Circuit Court",
@@ -21902,7 +21650,14 @@
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 707,
+      "ID": 410,
+      "Name": "Tiffany H. Anderson",
+      "Contest": "Judge of the Circuit Court",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7"
+    },
+    {
+      "ID": 701,
       "Name": "Tiffany Sue Mock",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21923,35 +21678,35 @@
       "District": "Saint Mary's County"
     },
     {
-      "ID": 695,
+      "ID": 690,
       "Name": "Tim Lattimer",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Timothy Hodgson Hamilton",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Howard County"
     },
     {
-      "ID": 665,
+      "ID": 660,
       "Name": "Timothy J. Bridges",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 44A"
     },
     {
-      "ID": 719,
+      "ID": 713,
       "Name": "Timothy Kingston",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 643,
+      "ID": 642,
       "Name": "Timothy L. Everd",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -21986,7 +21741,7 @@
       "District": "Legislative District 42B"
     },
     {
-      "ID": 783,
+      "ID": 776,
       "Name": "Timur Edib",
       "Contest": "Board of Education At Large",
       "Jurisdiction": "State of Maryland",
@@ -22028,7 +21783,7 @@
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 707,
+      "ID": 701,
       "Name": "Todd Joseph Logsdon",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22056,7 +21811,7 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Tom Bradley",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22077,18 +21832,18 @@
       "District": "Councilmanic District 1"
     },
     {
+      "ID": 686,
+      "Name": "Tom Desabla",
+      "Contest": "Democratic Central Committee Male",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County"
+    },
+    {
       "ID": 430,
       "Name": "Tom Desabla",
       "Contest": "County Commissioner",
       "Jurisdiction": "Charles County",
       "District": "Commissioner District 2"
-    },
-    {
-      "ID": 691,
-      "Name": "Tom Desabla",
-      "Contest": "Democratic Central Committee Male",
-      "Jurisdiction": "State of Maryland",
-      "District": "Charles County"
     },
     {
       "ID": 291,
@@ -22126,7 +21881,7 @@
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 756,
+      "ID": 749,
       "Name": "Tom Kennedy",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -22175,21 +21930,21 @@
       "District": "Montgomery County"
     },
     {
-      "ID": 697,
+      "ID": 692,
       "Name": "Tom Rider",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 731,
+      "ID": 725,
       "Name": "Tom Rodriguez",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 18"
     },
     {
-      "ID": 715,
+      "ID": 709,
       "Name": "Tom Sheahen",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22217,18 +21972,18 @@
       "District": "Legislative District 41"
     },
     {
-      "ID": 750,
-      "Name": "Tony Campbell",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 6"
-    },
-    {
       "ID": 7,
       "Name": "Tony Campbell",
       "Contest": "U.S. Senator",
       "Jurisdiction": "State of Maryland",
       "District": "State of Maryland"
+    },
+    {
+      "ID": 743,
+      "Name": "Tony Campbell",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 6"
     },
     {
       "ID": 286,
@@ -22259,7 +22014,7 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 771,
+      "ID": 764,
       "Name": "Tony Puca",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -22273,14 +22028,14 @@
       "District": "Legislative District 15"
     },
     {
-      "ID": 748,
+      "ID": 741,
       "Name": "Tony Ristaino",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "Tony Soltero",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -22315,7 +22070,7 @@
       "District": "Legislative District 33"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Tracy Elizabeth Miller",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22336,7 +22091,7 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 716,
+      "ID": 710,
       "Name": "Trevor Leach",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22357,13 +22112,6 @@
       "District": "Charles County"
     },
     {
-      "ID": 642,
-      "Name": "Tyler Hagen",
-      "Contest": "Democratic Central Committee",
-      "Jurisdiction": "State of Maryland",
-      "District": "Legislative District 7"
-    },
-    {
       "ID": 641,
       "Name": "Tyler Hagen",
       "Contest": "Democratic Central Committee",
@@ -22371,7 +22119,7 @@
       "District": "Legislative District 7"
     },
     {
-      "ID": 798,
+      "ID": 791,
       "Name": "Uju Elliffe",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
@@ -22385,7 +22133,7 @@
       "District": "Commissioner District 2"
     },
     {
-      "ID": 722,
+      "ID": 716,
       "Name": "\"Uncle Ray\" Grodecki",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22420,14 +22168,14 @@
       "District": "Washington County"
     },
     {
-      "ID": 651,
+      "ID": 648,
       "Name": "Vanessa Agbar",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 23A"
     },
     {
-      "ID": 725,
+      "ID": 719,
       "Name": "Vanessa Alban",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22469,7 +22217,7 @@
       "District": "Legislative District 26"
     },
     {
-      "ID": 645,
+      "ID": 644,
       "Name": "Veronika Beaver",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22490,7 +22238,7 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 782,
+      "ID": 775,
       "Name": "Vicky Cutroneo",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -22504,7 +22252,7 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 754,
+      "ID": 747,
       "Name": "Victor Clark, Jr.",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "Baltimore City",
@@ -22518,7 +22266,7 @@
       "District": "Legislative District 44"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Victoria \"Vicki\" Talley Kelly",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -22539,21 +22287,21 @@
       "District": "Congressional District 8"
     },
     {
-      "ID": 731,
+      "ID": 725,
       "Name": "Vincent Frederick DeCain",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 18"
     },
     {
-      "ID": 798,
+      "ID": 791,
       "Name": "Vincent Goldsmith",
       "Contest": "Board of Education",
       "Jurisdiction": "Anne Arundel County",
       "District": "Councilmanic District 5"
     },
     {
-      "ID": 711,
+      "ID": 705,
       "Name": "Vincent Sammons",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22567,28 +22315,28 @@
       "District": "Commissioner District 4"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Virginia Benedict",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 780,
+      "ID": 773,
       "Name": "Virginia \"Ginny\" McGraw",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 681,
+      "ID": 676,
       "Name": "Virginia L. Patterson",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
       "District": "Queen Anne's County"
     },
     {
-      "ID": 675,
+      "ID": 670,
       "Name": "Vontasha Simms",
       "Contest": "Democratic Central Committee Female",
       "Jurisdiction": "State of Maryland",
@@ -22623,30 +22371,30 @@
       "District": "Legislative District 34B"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Walter Carroll",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 700,
+      "ID": 695,
       "Name": "Walter E. Chase",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Talbot County"
     },
     {
-      "ID": 209,
+      "ID": 656,
       "Name": "Walter J. Horton",
-      "Contest": "House of Delegates",
+      "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
     {
-      "ID": 661,
+      "ID": 209,
       "Name": "Walter J. Horton",
-      "Contest": "Democratic Central Committee",
+      "Contest": "House of Delegates",
       "Jurisdiction": "State of Maryland",
       "District": "Legislative District 41"
     },
@@ -22672,7 +22420,7 @@
       "District": "Legislative District 47B"
     },
     {
-      "ID": 694,
+      "ID": 689,
       "Name": "Waqi Alam",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
@@ -22707,21 +22455,21 @@
       "District": "Washington County"
     },
     {
-      "ID": 691,
+      "ID": 686,
       "Name": "Wayne Magoon",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Charles County"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Wayne T. Foote",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
       "District": "Allegany County"
     },
     {
-      "ID": 670,
+      "ID": 665,
       "Name": "Wayne Thunder Williams",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22742,14 +22490,14 @@
       "District": "Prince George's County"
     },
     {
-      "ID": 724,
+      "ID": 718,
       "Name": "Wendy Anspacher",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Wicomico County"
     },
     {
-      "ID": 713,
+      "ID": 707,
       "Name": "Wendy Lewis Weber",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22763,7 +22511,7 @@
       "District": "Anne Arundel County"
     },
     {
-      "ID": 778,
+      "ID": 771,
       "Name": "Wesley G. Mason",
       "Contest": "Board of Education",
       "Jurisdiction": "State of Maryland",
@@ -22847,28 +22595,28 @@
       "District": "Legislative District 3B"
     },
     {
-      "ID": 692,
+      "ID": 687,
       "Name": "William \"Billy\" Reid",
       "Contest": "Democratic Central Committee Male",
       "Jurisdiction": "State of Maryland",
       "District": "Frederick County"
     },
     {
-      "ID": 800,
+      "ID": 793,
       "Name": "William Feuer",
       "Contest": "Board of Education",
       "Jurisdiction": "Baltimore County",
       "District": "Councilmanic District 7"
     },
     {
-      "ID": 710,
+      "ID": 704,
       "Name": "William Harrison",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
       "District": "Carroll County"
     },
     {
-      "ID": 717,
+      "ID": 711,
       "Name": "William H. Campbell",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22889,7 +22637,7 @@
       "District": "Legislative District 2A"
     },
     {
-      "ID": 785,
+      "ID": 778,
       "Name": "William J. Poad",
       "Contest": "Board of Education",
       "Jurisdiction": "Queen Anne's County",
@@ -22931,14 +22679,14 @@
       "District": "Baltimore County"
     },
     {
-      "ID": 409,
+      "ID": 408,
       "Name": "William R. Greer, Jr.",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
       "District": "Judicial Circuit 7"
     },
     {
-      "ID": 408,
+      "ID": 409,
       "Name": "William R. Greer, Jr.",
       "Contest": "Judge of the Circuit Court",
       "Jurisdiction": "State of Maryland",
@@ -22952,7 +22700,7 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 728,
+      "ID": 722,
       "Name": "William Sharon Richbourg",
       "Contest": "Republican Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -22980,18 +22728,18 @@
       "District": "Judicial Circuit 7"
     },
     {
+      "ID": 738,
+      "Name": "William T. Newton",
+      "Contest": "Republican Central Committee",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3"
+    },
+    {
       "ID": 21,
       "Name": "William T. Newton",
       "Contest": "Representative in Congress",
       "Jurisdiction": "State of Maryland",
       "District": "Congressional District 7"
-    },
-    {
-      "ID": 745,
-      "Name": "William T. Newton",
-      "Contest": "Republican Central Committee",
-      "Jurisdiction": "Baltimore County",
-      "District": "Councilmanic District 3"
     },
     {
       "ID": 571,
@@ -23050,7 +22798,7 @@
       "District": "Wicomico County"
     },
     {
-      "ID": 663,
+      "ID": 658,
       "Name": "Yasminah Abdullah",
       "Contest": "Democratic Central Committee",
       "Jurisdiction": "State of Maryland",
@@ -23069,6 +22817,1610 @@
       "Contest": "County Commissioner",
       "Jurisdiction": "Worcester County",
       "District": "Commissioner District 3"
+    }
+  ],
+  "AllDistricts": [
+    {
+      "ID": "3",
+      "Jurisdiction": "State of Maryland",
+      "District": "Allegany County",
+      "Type": "County"
+    },
+    {
+      "ID": "4",
+      "Jurisdiction": "State of Maryland",
+      "District": "Anne Arundel County",
+      "Type": "County"
+    },
+    {
+      "ID": "5",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore City",
+      "Type": "Municipality"
+    },
+    {
+      "ID": "6",
+      "Jurisdiction": "State of Maryland",
+      "District": "Baltimore County",
+      "Type": "County"
+    },
+    {
+      "ID": "500000043",
+      "Jurisdiction": "Montgomery County",
+      "District": "Board of Education District 3",
+      "Type": "Board of Education District"
+    },
+    {
+      "ID": "500000183",
+      "Jurisdiction": "Prince George's County",
+      "District": "Board of Education District 9",
+      "Type": "Board of Education District"
+    },
+    {
+      "ID": "500000037",
+      "Jurisdiction": "Prince George's County",
+      "District": "Board of Education District 2",
+      "Type": "Board of Education District"
+    },
+    {
+      "ID": "500000038",
+      "Jurisdiction": "Prince George's County",
+      "District": "Board of Education District 3",
+      "Type": "Board of Education District"
+    },
+    {
+      "ID": "500000180",
+      "Jurisdiction": "Prince George's County",
+      "District": "Board of Education District 6",
+      "Type": "Board of Education District"
+    },
+    {
+      "ID": "7",
+      "Jurisdiction": "State of Maryland",
+      "District": "Calvert County",
+      "Type": "County"
+    },
+    {
+      "ID": "8",
+      "Jurisdiction": "State of Maryland",
+      "District": "Caroline County",
+      "Type": "County"
+    },
+    {
+      "ID": "9",
+      "Jurisdiction": "State of Maryland",
+      "District": "Carroll County",
+      "Type": "County"
+    },
+    {
+      "ID": "10",
+      "Jurisdiction": "State of Maryland",
+      "District": "Cecil County",
+      "Type": "County"
+    },
+    {
+      "ID": "11",
+      "Jurisdiction": "State of Maryland",
+      "District": "Charles County",
+      "Type": "County"
+    },
+    {
+      "ID": "7626",
+      "Jurisdiction": "Somerset County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7211",
+      "Jurisdiction": "Saint Mary's County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6495",
+      "Jurisdiction": "Queen Anne's County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7780",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 6",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7209",
+      "Jurisdiction": "Saint Mary's County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000088",
+      "Jurisdiction": "Carroll County",
+      "District": "Commissioner District 5",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7158",
+      "Jurisdiction": "Charles County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000044",
+      "Jurisdiction": "Calvert County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7159",
+      "Jurisdiction": "Charles County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7210",
+      "Jurisdiction": "Saint Mary's County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7628",
+      "Jurisdiction": "Somerset County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6497",
+      "Jurisdiction": "Queen Anne's County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000085",
+      "Jurisdiction": "Carroll County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000087",
+      "Jurisdiction": "Carroll County",
+      "District": "Commissioner District 4",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7778",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7620",
+      "Jurisdiction": "Somerset County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7781",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 7",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000086",
+      "Jurisdiction": "Carroll County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000084",
+      "Jurisdiction": "Carroll County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6614",
+      "Jurisdiction": "Garrett County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6619",
+      "Jurisdiction": "Garrett County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7212",
+      "Jurisdiction": "Saint Mary's County",
+      "District": "Commissioner District 4",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7775",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 5",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000043",
+      "Jurisdiction": "Calvert County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6616",
+      "Jurisdiction": "Garrett County",
+      "District": "Commissioner District 3",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6498",
+      "Jurisdiction": "Queen Anne's County",
+      "District": "Commissioner District 4",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7622",
+      "Jurisdiction": "Somerset County",
+      "District": "Commissioner District 4",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7777",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7157",
+      "Jurisdiction": "Charles County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7624",
+      "Jurisdiction": "Somerset County",
+      "District": "Commissioner District 5",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "750000042",
+      "Jurisdiction": "Calvert County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7160",
+      "Jurisdiction": "Charles County",
+      "District": "Commissioner District 4",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7776",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 1",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "6496",
+      "Jurisdiction": "Queen Anne's County",
+      "District": "Commissioner District 2",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "7779",
+      "Jurisdiction": "Worcester County",
+      "District": "Commissioner District 4",
+      "Type": "Commissioner District"
+    },
+    {
+      "ID": "86",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 6",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "90",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 5",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "88",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 2",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "87",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 1",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "113",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 4",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "89",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 3",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "93",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 7",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "115",
+      "Jurisdiction": "State of Maryland",
+      "District": "Congressional District 8",
+      "Type": "Congressional District"
+    },
+    {
+      "ID": "5352",
+      "Jurisdiction": "Montgomery County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6337",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 6",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5355",
+      "Jurisdiction": "Montgomery County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5763",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 14",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5828",
+      "Jurisdiction": "Howard County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6352",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7522",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6277",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5755",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 6",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5762",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 13",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7698",
+      "Jurisdiction": "Dorchester County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6904",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000211",
+      "Jurisdiction": "Frederick County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000212",
+      "Jurisdiction": "Frederick County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6907",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 7",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5351",
+      "Jurisdiction": "Montgomery County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5354",
+      "Jurisdiction": "Montgomery County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7576",
+      "Jurisdiction": "Wicomico County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7519",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5760",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 11",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5756",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 7",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7524",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 6",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7694",
+      "Jurisdiction": "Dorchester County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000215",
+      "Jurisdiction": "Frederick County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7696",
+      "Jurisdiction": "Dorchester County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7695",
+      "Jurisdiction": "Dorchester County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5826",
+      "Jurisdiction": "Howard County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5751",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5750",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6485",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6328",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7574",
+      "Jurisdiction": "Wicomico County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7573",
+      "Jurisdiction": "Wicomico County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5753",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7525",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 7",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6402",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 7",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7527",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 9",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6903",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7520",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7697",
+      "Jurisdiction": "Dorchester County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5752",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5827",
+      "Jurisdiction": "Howard County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000214",
+      "Jurisdiction": "Frederick County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000203",
+      "Jurisdiction": "Cecil County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6902",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7572",
+      "Jurisdiction": "Wicomico County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7526",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 8",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5761",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 12",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000202",
+      "Jurisdiction": "Cecil County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000204",
+      "Jurisdiction": "Cecil County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6905",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7575",
+      "Jurisdiction": "Wicomico County",
+      "District": "Councilmanic District 4",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6906",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 6",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6901",
+      "Jurisdiction": "Anne Arundel County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5757",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 8",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5758",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 9",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5353",
+      "Jurisdiction": "Montgomery County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5759",
+      "Jurisdiction": "Baltimore City",
+      "District": "Councilmanic District 10",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5825",
+      "Jurisdiction": "Howard County",
+      "District": "Councilmanic District 2",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "500000213",
+      "Jurisdiction": "Frederick County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6293",
+      "Jurisdiction": "Baltimore County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7521",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 3",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "5824",
+      "Jurisdiction": "Howard County",
+      "District": "Councilmanic District 1",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "7523",
+      "Jurisdiction": "Prince George's County",
+      "District": "Councilmanic District 5",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6778",
+      "Jurisdiction": "Harford County",
+      "District": "Councilmanic District A",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6779",
+      "Jurisdiction": "Harford County",
+      "District": "Councilmanic District B",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6780",
+      "Jurisdiction": "Harford County",
+      "District": "Councilmanic District C",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6781",
+      "Jurisdiction": "Harford County",
+      "District": "Councilmanic District D",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6782",
+      "Jurisdiction": "Harford County",
+      "District": "Councilmanic District E",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "6783",
+      "Jurisdiction": "Harford County",
+      "District": "Councilmanic District F",
+      "Type": "Councilmanic District"
+    },
+    {
+      "ID": "12",
+      "Jurisdiction": "State of Maryland",
+      "District": "Dorchester County",
+      "Type": "County"
+    },
+    {
+      "ID": "13",
+      "Jurisdiction": "State of Maryland",
+      "District": "Frederick County",
+      "Type": "County"
+    },
+    {
+      "ID": "14",
+      "Jurisdiction": "State of Maryland",
+      "District": "Garrett County",
+      "Type": "County"
+    },
+    {
+      "ID": "15",
+      "Jurisdiction": "State of Maryland",
+      "District": "Harford County",
+      "Type": "County"
+    },
+    {
+      "ID": "16",
+      "Jurisdiction": "State of Maryland",
+      "District": "Howard County",
+      "Type": "County"
+    },
+    {
+      "ID": "159",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 1",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "151",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 5",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "155",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 2",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "154",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 7",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "150",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 4",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "160",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 6",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "152",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 8",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "153",
+      "Jurisdiction": "State of Maryland",
+      "District": "Judicial Circuit 3",
+      "Type": "Judicial Circuit"
+    },
+    {
+      "ID": "17",
+      "Jurisdiction": "State of Maryland",
+      "District": "Kent County",
+      "Type": "County"
+    },
+    {
+      "ID": "500000490",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000479",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000487",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000230",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "35",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 28",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000480",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "62",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000460",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000492",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000476",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000451",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "67",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000447",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000484",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000485",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 40",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000450",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 5",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "56",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000449",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 4",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "213",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000471",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 26",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000491",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 46",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000461",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "208",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 40",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000225",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000483",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000486",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000456",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000472",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "218",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "44",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000470",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000473",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 28",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000489",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000453",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "209",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 41",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "58",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "65",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000463",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "210",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 43",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000454",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000459",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000488",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 43",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000455",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 10",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "55",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 16",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000218",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 4",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000468",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000481",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "60",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 39",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "54",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 15",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "212",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 45",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000465",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000452",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 7",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "219",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 11",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000475",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "66",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 25",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000478",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 33",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "53",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 14",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "205",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "51",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 13",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000464",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 19",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000477",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 32",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000462",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 17",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000467",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 22",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000474",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000457",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 12",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000446",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "61",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "57",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 18",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000458",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 13",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "59",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 20",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "217",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 8",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000482",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "34",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 36",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000469",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 24",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000466",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 21",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "500000226",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 5",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000448",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3",
+      "Type": "Senatorial District"
+    },
+    {
+      "ID": "215",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 6",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "43",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000239",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "74",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000223",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "77",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "32",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "63",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "36",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000221",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "37",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "48",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "68",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000231",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "46",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "39",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000219",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44A",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "72",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000232",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 42B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "47",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 35B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "200",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "38",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 37B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000224",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 31B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000240",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 47B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000233",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 44B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000222",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 30B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "223",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "84",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "33",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 34B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "31",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 9B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "78",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 2B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "64",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 23B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "40",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 3B",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000241",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 38C",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "76",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 1C",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "73",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 29C",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "500000220",
+      "Jurisdiction": "State of Maryland",
+      "District": "Legislative District 27C",
+      "Type": "Legislative District"
+    },
+    {
+      "ID": "18",
+      "Jurisdiction": "State of Maryland",
+      "District": "Montgomery County",
+      "Type": "County"
+    },
+    {
+      "ID": "7693",
+      "Jurisdiction": "Dorchester County",
+      "District": "Orphans' Court District 1",
+      "Type": "Orphans' Court District"
+    },
+    {
+      "ID": "7692",
+      "Jurisdiction": "Dorchester County",
+      "District": "Orphans' Court District 2",
+      "Type": "Orphans' Court District"
+    },
+    {
+      "ID": "19",
+      "Jurisdiction": "State of Maryland",
+      "District": "Prince George's County",
+      "Type": "County"
+    },
+    {
+      "ID": "20",
+      "Jurisdiction": "State of Maryland",
+      "District": "Queen Anne's County",
+      "Type": "County"
+    },
+    {
+      "ID": "21",
+      "Jurisdiction": "State of Maryland",
+      "District": "Saint Mary's County",
+      "Type": "County"
+    },
+    {
+      "ID": "22",
+      "Jurisdiction": "State of Maryland",
+      "District": "Somerset County",
+      "Type": "County"
+    },
+    {
+      "ID": "2",
+      "Jurisdiction": "State of Maryland",
+      "District": "State of Maryland",
+      "Type": "State of Maryland"
+    },
+    {
+      "ID": "23",
+      "Jurisdiction": "State of Maryland",
+      "District": "Talbot County",
+      "Type": "County"
+    },
+    {
+      "ID": "24",
+      "Jurisdiction": "State of Maryland",
+      "District": "Washington County",
+      "Type": "County"
+    },
+    {
+      "ID": "25",
+      "Jurisdiction": "State of Maryland",
+      "District": "Wicomico County",
+      "Type": "County"
+    },
+    {
+      "ID": "26",
+      "Jurisdiction": "State of Maryland",
+      "District": "Worcester County",
+      "Type": "County"
     }
   ]
 }

--- a/layouts-robocopy/district.html
+++ b/layouts-robocopy/district.html
@@ -1,0 +1,5 @@
+{{ range . }}
+  <div class="district-contest">
+    {{ template "contest.html" . }}
+  </div>
+{{ end }}

--- a/layouts/results-page/single.html
+++ b/layouts/results-page/single.html
@@ -19,7 +19,7 @@
     {{ $baseURL := .Param "results-base-url" }}
     <div
         class="js-results-container"
-        data-fetch-url='{{.Param "results-base-url" }}1.html'
+        data-fetch-url='{{.Param "results-base-url" }}contests/1.html'
         data-target="#info"
         data-errors="#errors"
         data-time="#time"
@@ -29,7 +29,7 @@
           <button
             type="button"
             class="js-key-contests-btn"
-            value="{{ $baseURL }}{{ .ID }}.html">
+            value="{{ $baseURL }}contests/{{ .ID }}.html">
               {{- .Name -}}
           </button>
         {{ end }}
@@ -39,7 +39,7 @@
         <select class="all-contests js-select2">
           <option disabled selected>Choose by race name</option>
           {{ range .Site.Data.results.AllContests }}
-            <option value='{{ $baseURL }}{{ .ID }}.html'>
+            <option value='{{ $baseURL }}contests/{{ .ID }}.html'>
               {{- .Name -}}
               {{- if ne .Jurisdiction "State of Maryland" -}}
                 {{- " " -}}{{- .Jurisdiction -}}
@@ -56,14 +56,28 @@
 
         <select class="all-options js-select2">
           <option disabled selected>Choose by candidate name</option>
-          {{ range sort .Site.Data.results.AllOptions }}
-            <option value='{{ $baseURL }}{{ .ID }}.html'>
+          {{ range .Site.Data.results.AllOptions }}
+            <option value='{{ $baseURL }}contests/{{ .ID }}.html'>
               {{- .Name -}}
               {{- " • " }}{{ .Contest -}}
               {{- " • " }}{{ .District -}}
             </option>
           {{ end }}
         </select>
+
+        <select class="all-options js-select2">
+          <option disabled selected>Choose by district</option>
+          {{ range sort .Site.Data.results.AllDistricts "ID" }}
+            <option value='{{ $baseURL }}districts/{{ .ID }}.html'>
+              {{- if ne .Jurisdiction "State of Maryland" -}}
+                {{- .Jurisdiction -}}{{- " " -}}
+              {{- end -}}
+              {{- .District -}}
+              {{- if eq .Type "Senatorial District" }} (State Senate){{ end -}}
+            </option>
+          {{ end }}
+        </select>
+
 
         <div class="last-refresh">
           Page last refreshed: <span id="time">Still loading…</span>
@@ -83,4 +97,3 @@
     </div>
 </div>
 {{ end }}
-


### PR DESCRIPTION
The results-page/single.html conflicts with yours, but you can throw out almost all of my changes, except that you need to update all the data-fetch-urls to include /contest/ or /district/ as appropriate, and you'll want to copy my district select box. It's a new robocopy, so rebuild and copy it into your ~/bin.