### PR TITLE
Robocopy: Add barker updater

### DIFF
--- a/cmd/robocopy/p2p.go
+++ b/cmd/robocopy/p2p.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+type P2PClient struct{ Token string }
+
+func NewP2PClient() P2PClient {
+	return P2PClient{
+		Token: os.Getenv("P2P_ACCESS_TOKEN"),
+	}
+}
+
+func (pc P2PClient) Update(slug, content string) error {
+	const baseURL = "https://content-api.p2p.tribuneinteractive.com/content_items/%s.json?preserve_embedded_tags=false"
+	url := fmt.Sprintf(baseURL, slug)
+
+	type (
+		Body struct {
+			Body string `json:"body"`
+		}
+		Wrapper struct {
+			Content Body `json:"content_item"`
+		}
+	)
+
+	var body bytes.Buffer
+	enc := json.NewEncoder(&body)
+	_ = enc.Encode(Wrapper{Body{content}})
+
+	req, _ := http.NewRequest("PUT", url, &body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+pc.Token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("P2P connection error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("unexpected response code from P2P: %s", resp.Status)
+	}
+	return nil
+}

--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -46,6 +46,7 @@ type Config struct {
 	Region           string
 	Bucket           string
 	Path             string
+	P2PSlug          string
 	PollInterval     time.Duration
 	DevPort          int
 	NumWorkers       int
@@ -64,6 +65,7 @@ func FromArgs(args []string) *Config {
 	fl.StringVar(&conf.Region, "region", "us-east-1", "Amazon region for S3")
 	fl.StringVar(&conf.Bucket, "bucket", "elections2018-news-baltimoresun-com", "Amazon S3 bucket")
 	fl.StringVar(&conf.Path, "path", "/results/", "Amazon S3 destination path")
+	fl.StringVar(&conf.P2PSlug, "p2p-slug", "bs-2018-elections-primary-barker", "barker to update")
 	fl.DurationVar(&conf.PollInterval, "poll-interval", 30*time.Second, "time between refreshing S3")
 	fl.IntVar(&conf.DevPort, "dev-port", 9191, "port for dev server")
 	fl.IntVar(&conf.NumWorkers, "workers", 5, "number of upload workers")

--- a/layouts-robocopy/barker.html
+++ b/layouts-robocopy/barker.html
@@ -1,0 +1,8 @@
+{{ $gov := index . 1 }}
+
+<h1>Governor Results</h1>
+
+{{ range $gov.Options }}
+    {{ .Text | titlecase }}: {{ .TotalVotes | commas }}<br>
+    {{ .PercentageVotes | printf "%.1f" }}%<br>
+{{ end }}


### PR DESCRIPTION
The barker slug is `bs-2018-elections-primary-barker`. In live mode, it will update the barker right after it updates the S3 buckets. To test this locally, reinstall, run `robocopy -dev-server`, and go to http://localhost:9191/results/bs-2018-elections-primary-barker to see what the template does.