### PR TITLE
Robocopy: Separate cache time

### DIFF
--- a/cmd/robocopy/robocopy.go
+++ b/cmd/robocopy/robocopy.go
@@ -49,6 +49,7 @@ type Config struct {
 	BarkerSlug       string
 	StorySlug        string
 	PollInterval     time.Duration
+	CacheTime        time.Duration
 	DevPort          int
 	NumWorkers       int
 }
@@ -69,6 +70,7 @@ func FromArgs(args []string) *Config {
 	fl.StringVar(&conf.BarkerSlug, "barker-slug", "bs-2018-elections-primary-barker", "barker to update")
 	fl.StringVar(&conf.StorySlug, "story-slug", "bs-2018-elections-primary-story", "story to update")
 	fl.DurationVar(&conf.PollInterval, "poll-interval", 30*time.Second, "time between refreshing S3")
+	fl.DurationVar(&conf.CacheTime, "cache-time", 10*time.Second, "cache time header")
 	fl.IntVar(&conf.DevPort, "dev-port", 9191, "port for dev server")
 	fl.IntVar(&conf.NumWorkers, "workers", 5, "number of upload workers")
 	fl.Usage = func() {

--- a/cmd/robocopy/uploader.go
+++ b/cmd/robocopy/uploader.go
@@ -39,7 +39,7 @@ func (c *Config) RemoteExec() error {
 	var cl = client{
 		uploader: s3manager.NewUploader(s),
 		cachecontrol: aws.String(
-			fmt.Sprintf("public, max-age=%.0f", c.PollInterval.Seconds()),
+			fmt.Sprintf("public, max-age=%.0f", c.CacheTime.Seconds()),
 		),
 		metadata: m,
 	}


### PR DESCRIPTION
Changes it so the cache time header can be set separately from the poll time.