### PR TITLE
Contests: Remove extra period in date formating

### DIFF
--- a/layouts-robocopy/contest.html
+++ b/layouts-robocopy/contest.html
@@ -2,7 +2,7 @@
 {{ $nonPartisan := (eq (lowerAlpha .Party) "nonpartisan") }}
 {{ $isPrimary := .IsPrimary }}
 
-<div class="race" data-boe-update='{{ .LastUpdate.Format "3:04pm Jan. 2, 2006" }}'>
+<div class="race" data-boe-update='{{ .LastUpdate.Format "3:04pm Jan 2, 2006" }}'>
   {{ if ne .Jurisdiction "State of Maryland" }}
     <div class="sub-header">{{ .Jurisdiction }}</div>
   {{ end }}

--- a/layouts-robocopy/contest.html
+++ b/layouts-robocopy/contest.html
@@ -2,7 +2,7 @@
 {{ $nonPartisan := (eq (lowerAlpha .Party) "nonpartisan") }}
 {{ $isPrimary := .IsPrimary }}
 
-<div class="race" data-boe-update='{{ .LastUpdate.Format "3:04pm Jan 2, 2006" }}'>
+<div class="race" data-boe-update='{{ .LastUpdate.Format "3:04pm January 2, 2006" }}'>
   {{ if ne .Jurisdiction "State of Maryland" }}
     <div class="sub-header">{{ .Jurisdiction }}</div>
   {{ end }}


### PR DESCRIPTION
It was showing as updated in `May.` even though there's no abbreviation for "May".