### PR TITLE
JS: Fix a bug where select2 resets to the wrong value

### DIFF
--- a/static/scripts/javascript.js
+++ b/static/scripts/javascript.js
@@ -557,13 +557,7 @@ var app = {
         window.history.replaceState({}, "", "?show=" + contestURL);
 
         // reset other boxes
-        var tempVal = $(e.target).val();
-        $(".js-select2")
-          .val("0")
-          .trigger("change");
-        $(e.target)
-          .val(tempVal)
-          .trigger("change");
+        $(".js-select2").not(e.target).val("0").trigger("change");
       });
     }
 


### PR DESCRIPTION
If you had multiple options with the same value (e.g. multiple names in the same race), it would reset it to the first name to match the value, instead of leaving it alone.